### PR TITLE
【新增】生成EmmeLua文档类型接口

### DIFF
--- a/src/Luban.Job.Common/Source/Defs/TTypeTemplateCommonExtends.cs
+++ b/src/Luban.Job.Common/Source/Defs/TTypeTemplateCommonExtends.cs
@@ -101,9 +101,9 @@ namespace Luban.Job.Common.Defs
             return type.Apply(LuaCommentTypeVisitor.Ins);
         }
         
-        public static string EmmeLuaCommentType(TType type)
+        public static string EmmyLuaCommentType(TType type)
         {
-            return type.Apply(EmmeLuaCommentTypeVisitor.Ins);
+            return type.Apply(EmmyLuaCommentTypeVisitor.Ins);
         }
 
         public static string LuaSerializeWhileNil(string bufName, string fieldName, TType type)

--- a/src/Luban.Job.Common/Source/Defs/TTypeTemplateCommonExtends.cs
+++ b/src/Luban.Job.Common/Source/Defs/TTypeTemplateCommonExtends.cs
@@ -100,6 +100,11 @@ namespace Luban.Job.Common.Defs
         {
             return type.Apply(LuaCommentTypeVisitor.Ins);
         }
+        
+        public static string EmmeLuaCommentType(TType type)
+        {
+            return type.Apply(EmmeLuaCommentTypeVisitor.Ins);
+        }
 
         public static string LuaSerializeWhileNil(string bufName, string fieldName, TType type)
         {

--- a/src/Luban.Job.Common/Source/TypeVisitors/EmmeLuaCommentTypeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/EmmeLuaCommentTypeVisitor.cs
@@ -1,0 +1,124 @@
+using Luban.Job.Common.Types;
+
+namespace Luban.Job.Common.TypeVisitors
+{
+    public class EmmeLuaCommentTypeVisitor : ITypeFuncVisitor<string>
+    {
+        public static EmmeLuaCommentTypeVisitor Ins { get; } = new EmmeLuaCommentTypeVisitor();
+
+        public string Accept(TBool type)
+        {
+            return "boolean";
+        }
+
+        public string Accept(TByte type)
+        {
+            return "number";
+        }
+
+        public string Accept(TShort type)
+        {
+            return "number";
+        }
+
+        public string Accept(TFshort type)
+        {
+            return "number";
+        }
+
+        public string Accept(TInt type)
+        {
+            return "number";
+        }
+
+        public string Accept(TFint type)
+        {
+            return "number";
+        }
+
+        public string Accept(TLong type)
+        {
+            return "number";
+        }
+
+        public string Accept(TFlong type)
+        {
+            return "number";
+        }
+
+        public string Accept(TFloat type)
+        {
+            return "number";
+        }
+
+        public string Accept(TDouble type)
+        {
+            return "number";
+        }
+
+        public string Accept(TEnum type)
+        {
+            return type.DefineEnum.FullName;
+        }
+
+        public string Accept(TString type)
+        {
+            return "string";
+        }
+
+        public string Accept(TBytes type)
+        {
+            return $"string";
+        }
+
+        public string Accept(TText type)
+        {
+            return "string";
+        }
+
+        public string Accept(TBean type)
+        {
+            return type.Bean.FullName;
+        }
+
+        public string Accept(TArray type)
+        {
+            return $"{type.ElementType.Apply(this)}[]";
+        }
+
+        public string Accept(TList type)
+        {
+            return $"{type.ElementType.Apply(this)}[]";
+        }
+
+        public string Accept(TSet type)
+        {
+            return $"{type.ElementType.Apply(this)}[]";
+        }
+
+        public string Accept(TMap type)
+        {
+            return $"table<{type.KeyType.Apply(this)},{type.ValueType.Apply(this)}>";
+        }
+
+        public string Accept(TVector2 type)
+        {
+            return "vector2";
+        }
+
+        public string Accept(TVector3 type)
+        {
+            return "vector3";
+        }
+
+        public string Accept(TVector4 type)
+        {
+            return "vector4";
+        }
+
+        public string Accept(TDateTime type)
+        {
+            return "number";
+        }
+    }
+}

--- a/src/Luban.Job.Common/Source/TypeVisitors/EmmyLuaCommentTypeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/EmmyLuaCommentTypeVisitor.cs
@@ -68,7 +68,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TBytes type)
         {
-            return $"string";
+            return "string";
         }
 
         public string Accept(TText type)

--- a/src/Luban.Job.Common/Source/TypeVisitors/EmmyLuaCommentTypeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/EmmyLuaCommentTypeVisitor.cs
@@ -2,9 +2,9 @@ using Luban.Job.Common.Types;
 
 namespace Luban.Job.Common.TypeVisitors
 {
-    public class EmmeLuaCommentTypeVisitor : ITypeFuncVisitor<string>
+    public class EmmyLuaCommentTypeVisitor : ITypeFuncVisitor<string>
     {
-        public static EmmeLuaCommentTypeVisitor Ins { get; } = new EmmeLuaCommentTypeVisitor();
+        public static EmmyLuaCommentTypeVisitor Ins { get; } = new EmmyLuaCommentTypeVisitor();
 
         public string Accept(TBool type)
         {


### PR DESCRIPTION
使用模板生成时,通过该接口将表中类型映射为EmmeLua文档类型,可充分利用EmmeLua插件完成智能提示,效果如下
生成的文档注释:
![image](https://user-images.githubusercontent.com/90245066/152290804-0330a1d3-7f6f-451f-b974-74c2f4c4df24.png)
插件智能提示:
![image](https://user-images.githubusercontent.com/90245066/152289667-64f94c4f-dada-499b-a116-d816d6124963.png)
![image](https://user-images.githubusercontent.com/90245066/152289801-90fe48a3-dcd0-4300-8829-d279a5e19193.png)
![image](https://user-images.githubusercontent.com/90245066/152290161-4b176fb5-39ef-4ffd-a55e-30f770403abd.png)


