### PR TITLE
fix publish single file

### DIFF
--- a/src/Luban.Common/Source/Utils/FileUtil.cs
+++ b/src/Luban.Common/Source/Utils/FileUtil.cs
@@ -14,7 +14,7 @@ namespace Luban.Common.Utils
 
         public static string GetApplicationDirectory()
         {
-            return Path.GetDirectoryName(System.Reflection.Assembly.GetCallingAssembly().Location);
+            return AppContext.BaseDirectory;
         }
 
         public static string GetPathRelateApplicationDirectory(string relatePath)


### PR DESCRIPTION
fix System.Reflection.Assembly.GetCallingAssembly().Location return empty string when publish single file
see https://github.com/dotnet/corert/issues/5467