### PR TITLE
[change] 使用int64存储datetime类型，避免读取日期超过2038年出现问题

### DIFF
--- a/src/Luban.Job.Cfg/Source/DataExporters/BinaryExportor.cs
+++ b/src/Luban.Job.Cfg/Source/DataExporters/BinaryExportor.cs
@@ -179,7 +179,7 @@ namespace Luban.Job.Cfg.DataExporters
 
         public void Accept(DDateTime type, ByteBuf x)
         {
-            x.WriteInt(type.UnixTimeOfCurrentAssembly);
+            x.WriteLong(type.UnixTimeOfCurrentAssembly);
         }
     }
 }

--- a/src/Luban.Job.Cfg/Source/DataExporters/ProtobufBinExportor.cs
+++ b/src/Luban.Job.Cfg/Source/DataExporters/ProtobufBinExportor.cs
@@ -87,7 +87,7 @@ namespace Luban.Job.Cfg.DataExporters
 
         public void Accept(DDateTime type, CodedOutputStream x)
         {
-            x.WriteInt32(type.UnixTimeOfCurrentAssembly);
+            x.WriteInt64(type.UnixTimeOfCurrentAssembly);
         }
 
         public void Accept(DString type, CodedOutputStream x)

--- a/src/Luban.Job.Cfg/Source/Datas/DDateTime.cs
+++ b/src/Luban.Job.Cfg/Source/Datas/DDateTime.cs
@@ -11,7 +11,7 @@ namespace Luban.Job.Cfg.Datas
         public DateTime Time { get; }
 
         //public int UnixTime { get; }
-        private readonly int _localTime;
+        private readonly long _localTime;
 
         public override string TypeName => "datetime";
 
@@ -21,7 +21,7 @@ namespace Luban.Job.Cfg.Datas
             this.Time = time;
             // time.Kind == DateTimeKind.Unspecified
             // DateTimeOffset把它当作Local处理
-            this._localTime = (int)new DateTimeOffset(TimeZoneInfo.ConvertTime(time, TimeZoneUtil.DefaultTimeZone, TimeZoneInfo.Utc)).ToUnixTimeSeconds();
+            this._localTime = (long)new DateTimeOffset(TimeZoneInfo.ConvertTime(time, TimeZoneUtil.DefaultTimeZone, TimeZoneInfo.Utc)).ToUnixTimeSeconds();
         }
 
         public override bool Equals(object obj)
@@ -48,7 +48,7 @@ namespace Luban.Job.Cfg.Datas
             return DataUtil.FormatDateTime(Time);
         }
 
-        public int GetUnixTime(TimeZoneInfo asTimeZone)
+        public long GetUnixTime(TimeZoneInfo asTimeZone)
         {
             if (asTimeZone == null || asTimeZone == TimeZoneInfo.Local)
             {
@@ -57,11 +57,11 @@ namespace Luban.Job.Cfg.Datas
             else
             {
                 var destDateTime = TimeZoneInfo.ConvertTime(Time, asTimeZone, TimeZoneInfo.Utc);
-                return (int)new DateTimeOffset(destDateTime).ToUnixTimeSeconds();
+                return (long)new DateTimeOffset(destDateTime).ToUnixTimeSeconds();
             }
         }
 
-        public int UnixTimeOfCurrentAssembly => GetUnixTime(DefAssembly.LocalAssebmly.TimeZone);
+        public long UnixTimeOfCurrentAssembly => GetUnixTime(DefAssembly.LocalAssebmly.TimeZone);
 
         public override void Apply<T>(IDataActionVisitor<T> visitor, T x)
         {

--- a/src/Luban.Job.Cfg/Source/TypeVisitors/CppUnderingDeserializeVisitor.cs
+++ b/src/Luban.Job.Cfg/Source/TypeVisitors/CppUnderingDeserializeVisitor.cs
@@ -120,7 +120,7 @@ namespace Luban.Job.Cfg.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName)
         {
-            return $"if(!{bufName}.readInt({fieldName})) return false;";
+            return $"if(!{bufName}.readLong({fieldName})) return false;";
         }
     }
 }

--- a/src/Luban.Job.Cfg/Source/TypeVisitors/CsJsonDeserialize.cs
+++ b/src/Luban.Job.Cfg/Source/TypeVisitors/CsJsonDeserialize.cs
@@ -150,7 +150,7 @@ namespace Luban.Job.Cfg.TypeVisitors
 
         public string Accept(TDateTime type, string json, string x, int depth)
         {
-            return $"{x} = {json}.GetInt32();";
+            return $"{x} = {json}.GetInt64();";
         }
     }
 }

--- a/src/Luban.Job.Cfg/Source/TypeVisitors/JavaJsonDeserialize.cs
+++ b/src/Luban.Job.Cfg/Source/TypeVisitors/JavaJsonDeserialize.cs
@@ -152,7 +152,7 @@ namespace Luban.Job.Cfg.TypeVisitors
 
         public string Accept(TDateTime type, string json, string x, int depth)
         {
-            return $"{x} = {json}.getAsInt();";
+            return $"{x} = {json}.getAsLong();";
         }
     }
 }

--- a/src/Luban.Job.Cfg/Source/TypeVisitors/JavaUnderingDeserializeVisitor.cs
+++ b/src/Luban.Job.Cfg/Source/TypeVisitors/JavaUnderingDeserializeVisitor.cs
@@ -127,7 +127,7 @@ namespace Luban.Job.Cfg.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName)
         {
-            return $"{fieldName} = {bufName}.readInt();";
+            return $"{fieldName} = {bufName}.readLong();";
         }
     }
 }

--- a/src/Luban.Job.Cfg/Source/TypeVisitors/RustJsonUnderingConstructorVisitor.cs
+++ b/src/Luban.Job.Cfg/Source/TypeVisitors/RustJsonUnderingConstructorVisitor.cs
@@ -125,7 +125,7 @@ namespace Luban.Job.Cfg.TypeVisitors
 
         public string Accept(TDateTime type, string jsonVarName)
         {
-            return AsType(jsonVarName, "i32");
+            return AsType(jsonVarName, "i64");
         }
     }
 }

--- a/src/Luban.Job.Cfg/Source/TypeVisitors/UeBpCppDefineTypeVisitor.cs
+++ b/src/Luban.Job.Cfg/Source/TypeVisitors/UeBpCppDefineTypeVisitor.cs
@@ -122,7 +122,7 @@ namespace Luban.Job.Cfg.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "int32";
+            return "int64";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/CsUnderingDefineTypeName.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/CsUnderingDefineTypeName.cs
@@ -152,7 +152,7 @@ namespace Luban.Job.Common.TypeVisitors
             {
                 return mapper.TargetTypeName;
             }
-            return "int";
+            return "long";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/CsUnderingDeserializeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/CsUnderingDeserializeVisitor.cs
@@ -152,7 +152,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName, int depth)
         {
-            string src = $"{bufName}.ReadInt()";
+            string src = $"{bufName}.ReadLong()";
             return $"{fieldName} = {ExternalTypeUtil.CsCloneToExternal("datetime", src)};";
         }
     }

--- a/src/Luban.Job.Common/Source/TypeVisitors/CsUnderingSerializeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/CsUnderingSerializeVisitor.cs
@@ -122,7 +122,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName)
         {
-            return $"{bufName}.WriteInt({fieldName});";
+            return $"{bufName}.WriteLong({fieldName});";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/FlatBuffersTypeNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/FlatBuffersTypeNameVisitor.cs
@@ -98,7 +98,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "int32";
+            return "int64";
         }
 
         public string Accept(TBean type)

--- a/src/Luban.Job.Common/Source/TypeVisitors/GoDeserializeUnderingVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/GoDeserializeUnderingVisitor.cs
@@ -94,7 +94,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string fieldName, string bufName, string err)
         {
-            return $"{{ if {fieldName}, {err} = {bufName}.ReadInt(); {err} != nil {{ {err} = errors.New(\"{fieldName} error\"); return }} }}";
+            return $"{{ if {fieldName}, {err} = {bufName}.ReadLong(); {err} != nil {{ {err} = errors.New(\"{fieldName} error\"); return }} }}";
         }
 
         public string Accept(TBean type, string fieldName, string bufName, string err)

--- a/src/Luban.Job.Common/Source/TypeVisitors/GoSerializeUnderingVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/GoSerializeUnderingVisitor.cs
@@ -94,7 +94,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string fieldName, string bufName)
         {
-            return $"{bufName}.WriteInt({fieldName})";
+            return $"{bufName}.WriteLong({fieldName})";
         }
 
         public string Accept(TBean type, string fieldName, string bufName)

--- a/src/Luban.Job.Common/Source/TypeVisitors/GoTypeUnderingNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/GoTypeUnderingNameVisitor.cs
@@ -119,7 +119,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "int32";
+            return "int64";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/JavaBoxDefineTypeName.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/JavaBoxDefineTypeName.cs
@@ -58,7 +58,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public override string Accept(TDateTime type)
         {
-            return "Integer";
+            return "Long";
         }
 
         public override string Accept(TEnum type)

--- a/src/Luban.Job.Common/Source/TypeVisitors/JavaDefineTypeName.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/JavaDefineTypeName.cs
@@ -119,7 +119,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public virtual string Accept(TDateTime type)
         {
-            return type.IsNullable ? "Integer" : "int";
+            return type.IsNullable ? "Long" : "long";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/JavaUnderingDeserializeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/JavaUnderingDeserializeVisitor.cs
@@ -149,7 +149,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName, int depth)
         {
-            return $"{fieldName} = {bufName}.readInt();";
+            return $"{fieldName} = {bufName}.readLong();";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/JavaUnderingSerializeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/JavaUnderingSerializeVisitor.cs
@@ -122,7 +122,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName)
         {
-            return $"{bufName}.writeInt({fieldName});";
+            return $"{bufName}.writeLong({fieldName});";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/LuaDeserializeMethodNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/LuaDeserializeMethodNameVisitor.cs
@@ -118,7 +118,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "readInt";
+            return "readLong";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/LuaSerializeMethodNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/LuaSerializeMethodNameVisitor.cs
@@ -118,7 +118,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "writeInt";
+            return "writeLong";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/ProtobufTypeNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/ProtobufTypeNameVisitor.cs
@@ -98,7 +98,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "int32";
+            return "int64";
         }
 
         public string Accept(TBean type)

--- a/src/Luban.Job.Common/Source/TypeVisitors/RustTypeUnderlyingNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/RustTypeUnderlyingNameVisitor.cs
@@ -118,7 +118,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "i32";
+            return "i64";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/TagNameVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/TagNameVisitor.cs
@@ -118,7 +118,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "INT";
+            return "LONG";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/TypescriptBinUnderingDeserializeVisitorBase.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/TypescriptBinUnderingDeserializeVisitorBase.cs
@@ -166,7 +166,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string bufVarName, string fieldName)
         {
-            return $"{fieldName} = {bufVarName}.ReadInt()";
+            return $"{fieldName} = {bufVarName}.ReadLong()";
         }
     }
 }

--- a/src/Luban.Job.Common/Source/TypeVisitors/TypescriptBinUnderingSerializeVisitor.cs
+++ b/src/Luban.Job.Common/Source/TypeVisitors/TypescriptBinUnderingSerializeVisitor.cs
@@ -93,7 +93,7 @@ namespace Luban.Job.Common.TypeVisitors
 
         public string Accept(TDateTime type, string bufVarName, string fieldName)
         {
-            return $"{bufVarName}.WriteInt({fieldName})";
+            return $"{bufVarName}.WriteLong({fieldName})";
         }
 
         public virtual string Accept(TBean type, string bufVarName, string fieldName)

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbCsCompatibleDeserializeVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbCsCompatibleDeserializeVisitor.cs
@@ -151,7 +151,7 @@ namespace Luban.Job.Db.TypeVisitors
 
         public string Accept(TDateTime type, string bufName, string fieldName)
         {
-            return $"{fieldName} = {bufName}.ReadInt();";
+            return $"{fieldName} = {bufName}.ReadLong();";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbCsCompatibleSerializeVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbCsCompatibleSerializeVisitor.cs
@@ -150,9 +150,9 @@ namespace Luban.Job.Db.TypeVisitors
             return $"{bufName}.WriteVector4({fieldName});";
         }
 
-        public string Accept(TDateTime type, string x, string y)
+        public string Accept(TDateTime type, string bufName, string fieldName)
         {
-            throw new NotImplementedException();
+            return $"{bufName}.WriteLong({fieldName});";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbCsDeserializeFuncVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbCsDeserializeFuncVisitor.cs
@@ -128,7 +128,7 @@ namespace Luban.Job.Db.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "Bright.Common.SerializationUtil.DeserializeInt";
+            return "Bright.Common.SerializationUtil.DeserializeLong";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbCsInitFieldVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbCsInitFieldVisitor.cs
@@ -131,7 +131,7 @@ namespace Luban.Job.Db.TypeVisitors
 
         public string Accept(TDateTime type, string fieldName)
         {
-            throw new NotSupportedException();
+            return $"{fieldName} = default;";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbCsSerializeFuncVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbCsSerializeFuncVisitor.cs
@@ -128,7 +128,7 @@ namespace Luban.Job.Db.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "Bright.Common.SerializationUtil.SerializeInt";
+            return "Bright.Common.SerializationUtil.SerializeLong";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbTypescriptDeserializeFuncVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbTypescriptDeserializeFuncVisitor.cs
@@ -128,7 +128,7 @@ namespace Luban.Job.Db.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "SerializeFactory.deserializeInt";
+            return "SerializeFactory.deserializeLong";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbTypescriptInitFieldVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbTypescriptInitFieldVisitor.cs
@@ -130,9 +130,10 @@ namespace Luban.Job.Db.TypeVisitors
             return $"{fieldName} = new Vector4()";
         }
 
-        public string Accept(TDateTime type, string x, string y)
+        public string Accept(TDateTime type, string fieldName, string logType
+            )
         {
-            throw new NotSupportedException();
+            return $"{fieldName} = 0";
         }
     }
 }

--- a/src/Luban.Job.Db/Source/TypeVisitors/DbTypescriptSerializeFuncVisitor.cs
+++ b/src/Luban.Job.Db/Source/TypeVisitors/DbTypescriptSerializeFuncVisitor.cs
@@ -128,7 +128,7 @@ namespace Luban.Job.Db.TypeVisitors
 
         public string Accept(TDateTime type)
         {
-            return "SerializeFactory.serializeInt";
+            return "SerializeFactory.serializeLong";
         }
     }
 }


### PR DESCRIPTION
遇到的一个标准2038问题，由于datetime目前是4字节存储，excel表格中填写2099-01-01 01会变负数，是否可以考虑用long存储datetime？