### PR TITLE
修复enum枚举导出protobuf schema未包含EMPTY_PLACEHOLDER占位

### DIFF
--- a/src/Luban.Protobuf/Templates/pb/schema.sbn
+++ b/src/Luban.Protobuf/Templates/pb/schema.sbn
@@ -6,11 +6,11 @@ package {{__namespace}};
     typeName = full_name enum
  ~}}
 enum {{typeName}} {
+    {{~if !enum.has_zero_value_item ~}}
+    {{typeName}}_EMPTY_PLACEHOLDER = 0;
+    {{~end~}}
     {{~for item in enum.items ~}}
     {{typeName}}_{{item.name}} = {{item.int_value}};
-    {{~end~}}
-    {{~if enum.items.empty?}}
-    {{typeName}}_EMPTY_PLACEHOLDER = 0;
     {{~end~}}
 }
 {{~end~}}


### PR DESCRIPTION
![image](https://github.com/focus-creative-games/luban/assets/49706424/9d245bf1-9e5f-4944-b540-a591340b2edd)
![image](https://github.com/focus-creative-games/luban/assets/49706424/4ec16538-85e7-495b-958e-bc73190319a7)
