### PR TITLE
[fix] 修复 -t 参数非法时, 未进行 null check 导致的运行问题

### DIFF
--- a/src/Luban.Core/CodeTarget/CodeTargetBase.cs
+++ b/src/Luban.Core/CodeTarget/CodeTargetBase.cs
@@ -39,12 +39,16 @@ public abstract class CodeTargetBase : ICodeTarget
     public virtual void Handle(GenerationContext ctx, OutputFileManifest manifest)
     {
         var tasks = new List<Task<OutputFile>>();
-        tasks.Add(Task.Run(() =>
+
+        if(!string.IsNullOrEmpty(ctx.Target.Manager))
         {
-            var writer = new CodeWriter();
-            GenerateTables(ctx, ctx.ExportTables, writer);
-            return new OutputFile(){ File = $"{GetFileNameWithoutExtByTypeName(ctx.Target.Manager)}.{FileSuffixName}", Content = writer.ToResult(FileHeader) };
-        }));
+            tasks.Add(Task.Run(() =>
+            {
+                var writer = new CodeWriter();
+                GenerateTables(ctx, ctx.ExportTables, writer);
+                return new OutputFile(){ File = $"{GetFileNameWithoutExtByTypeName(ctx.Target.Manager)}.{FileSuffixName}", Content = writer.ToResult(FileHeader) };
+            })); 
+        }
 
         foreach (var table in ctx.ExportTables)
         {

--- a/src/Luban.Core/Defs/DefAssembly.cs
+++ b/src/Luban.Core/Defs/DefAssembly.cs
@@ -26,7 +26,14 @@ public class DefAssembly
 
     public RawTarget GetTarget(string targetName)
     {
-        return _targets.Find(t => t.Name == targetName);
+        var target = _targets.Find(t => t.Name == targetName);
+
+        if(target is null)
+        {
+            throw new Exception($"target is null {targetName}");
+        }
+
+        return target;
     }
 
     private readonly List<DefTable> _exportTables;


### PR DESCRIPTION
当 -t xxx 在 luban.conf 中不存在时，Assembly.Target 为空 的问题