### PR TITLE
gds版本优化

### DIFF
--- a/src/Luban.Gdscript/TemplateExtensions/GdscriptCommonTemplateExtension.cs
+++ b/src/Luban.Gdscript/TemplateExtensions/GdscriptCommonTemplateExtension.cs
@@ -21,6 +21,6 @@ public class GdscriptCommonTemplateExtension : ScriptObject
     
     public static string StrFullName(string fullName)
     {
-        return fullName.Replace(".", "_");
+        return TypeUtil.ToPascalCase(fullName.Replace(".", "_"));
     }
 }

--- a/src/Luban.Gdscript/TemplateExtensions/GdscriptJsonTemplateExtension.cs
+++ b/src/Luban.Gdscript/TemplateExtensions/GdscriptJsonTemplateExtension.cs
@@ -24,11 +24,11 @@ public class GdscriptJsonTemplateExtension : ScriptObject
     {
         if (type.IsNullable)
         {
-            return $"if {jsonVarName}.get('{jsonFieldName}') != null: {type.Apply(UnderlyingDeserializeVisitor.Ins, $"{jsonVarName}['{jsonFieldName}']", fieldName)}";
+            return $"if {jsonVarName}.get('{jsonFieldName}') != null: {type.Apply(UnderlyingDeserializeVisitor.Ins, $"{jsonVarName}[\"{jsonFieldName}\"]", fieldName)}";
         }
         else
         {
-            return type.Apply(UnderlyingDeserializeVisitor.Ins, $"{jsonVarName}['{jsonFieldName}']", fieldName);
+            return type.Apply(UnderlyingDeserializeVisitor.Ins, $"{jsonVarName}[\"{jsonFieldName}\"]", fieldName);
         }
     }
 }

--- a/src/Luban.Gdscript/Templates/gdscript-json/schema.sbn
+++ b/src/Luban.Gdscript/Templates/gdscript-json/schema.sbn
@@ -1,26 +1,39 @@
-
+## 所有配置表导出的管理类（包括枚举，数据类Bean，单行数据类组合而成的表格数据类Table，以及表格数据类组合而成的表格管理类Tables）
+@tool
 class_name Schema
+extends RefCounted
+
 
 {{~for enum in __enums~}}
 {{~if enum.comment != '' ~}}
-# {{enum.comment | html.escape}}
+## {{enum.comment | html.escape}}
 {{~end~}}
 enum {{full_name enum}}
 {
     {{~ for item in enum.items ~}}
-    {{item.name}} = {{item.value}},{{-if item.comment_or_alias != '' }}# {{item.comment_or_alias | html.escape}}{{-end}}
+    {{~if item.comment_or_alias != '' ~}}
+    ## {{item.comment_or_alias | html.escape}}
+    {{~end~}}
+    {{item.name}} = {{item.value}},
     {{~end~}}
 }
 
-{{~end~}}
 
+{{~end~}}
 {{~for bean in __beans
     name = (full_name bean)
 ~}}
-class {{name}} {{if bean.parent_def_type}}extends {{full_name bean.parent_def_type}}{{end}}:
+{{~if bean.comment != '' ~}}
+## {{bean.comment | html.escape}}
+{{~end~}}
+class {{name}}{{if bean.parent_def_type}} extends {{full_name bean.parent_def_type}}{{end}}:
 {{~ for field in bean.export_fields ~}}
+    {{~if field.comment != '' ~}}
+    ## {{field.comment | html.escape}}
+    {{~end~}}
     var {{format_field_name __code_style field.name}}: {{declaring_type_name field.ctype}}
 {{~end~}}
+
 {{~if bean.is_abstract_type~}}
     static func fromJson(_json_):
         var type = _json_['$type']
@@ -29,8 +42,8 @@ class {{name}} {{if bean.parent_def_type}}extends {{full_name bean.parent_def_ty
             "{{impl_data_type child bean}}": return {{full_name child}}.new(_json_)
         {{~end~}}
             _: assert(false)
-{{~end~}}
 
+{{~end~}}
     func _init(_json_) -> void:
 {{~if bean.parent_def_type~}}
         super(_json_)
@@ -42,70 +55,139 @@ class {{name}} {{if bean.parent_def_type}}extends {{full_name bean.parent_def_ty
         pass
         {{~end~}}
 
-{{~end~}}
 
+{{~end~}}
 {{~for table in __tables
     value_type = table.value_ttype
     value_type_name = (declaring_type_name value_type)
 ~}}
+{{~if table.comment != '' ~}}
+## {{table.comment | html.escape}}
+{{~end~}}
 class {{full_name table}}:
     {{~if table.is_map_table ~}}
-    var _data_list = []
-    var _data_map = {}
-    func _init(_json_ ) -> void:
-        self._data_map = {}
-        self._data_list = []
-        
+    ## 数据数组
+    var _data_list: Array[{{value_type_name}}]
+    ## 数据字典
+    var _data_map: Dictionary
+    
+    func _init(_json_) -> void:
         for _json2_ in _json_:
-            var _v
+            var _v: {{value_type_name}}
             {{deserialize '_v' '_json2_' value_type}}
             self._data_list.append(_v)
             self._data_map[_v.{{format_field_name __code_style table.index_field.name}}] = _v
 
-    func get_data_map() -> Dictionary : return self._data_map
-    func get_data_list() -> Array : return self._data_list
+    ## 获取数据数组
+    func get_data_list() -> Array[{{value_type_name}}]:
+        return self._data_list
 
-    func get_item(key) -> {{value_type_name}} : return self._data_map.get(key)
-    {{~else if table.is_list_table ~}}
-    var _data_list = []
-    func _init(_json_):
-        self._data_list = []
-        
+    ## 获取数据字典
+    func get_data_map() -> Dictionary:
+        return self._data_map
+
+    ## 获取键值对应的行数据对象
+    func get_item(key) -> {{value_type_name}}:
+        return self._data_map.get(key)
+
+    {{~else if table.multi_key ~}}
+    ## 数据数组
+    var _data_list: Array[{{value_type_name}}]
+    ## 数据字典
+    var _data_map: Dictionary
+    {{~ for INDEX in table.index_list ~}}
+    var _{{INDEX.index_field.name}}_data_map: Dictionary ## 以{{INDEX.index_field.name}}为key的数据字典
+    {{~ end ~}} 
+
+    func _init(_json_) -> void:
+        {{~ for INDEX in table.index_list ~}}
+        self._{{INDEX.index_field.name}}_data_map = {}
+        {{~ end ~}}
+    
         for _json2_ in _json_:
-            var _v
+            var _v: {{value_type_name}}
+            {{deserialize '_v' '_json2_' value_type}}
+            self._data_list.append(_v)
+            self._data_map[_v.{{format_field_name __code_style table.index_field.name}}] = _v
+        {{~ for INDEX in table.index_list ~}}
+            self._{{INDEX.index_field.name}}_data_map[_v.{{INDEX.index_field.name}}] = _v
+        {{~ end ~}}
+
+    ## 获取数据数组
+    func get_data_list() -> Array[{{value_type_name}}]:
+        return self._data_list
+
+    ## 获取数据字典
+    func get_data_map() -> Dictionary:
+        return self._data_map
+
+    {{~ for INDEX in table.index_list ~}}
+    ## 获取以{{INDEX.index_field.name}}为key的数据字典
+    func get_{{INDEX.index_field.name}}_data_map() -> Dictionary:
+        return self._{{INDEX.index_field.name}}_data_map
+
+    {{~ end ~}}
+    ## 通过默认key获取行数据对象
+    func get_item(key) -> {{value_type_name}}:
+        return self._data_map.get(key)
+
+{{~ for INDEX in table.index_list ~}}
+    ## 通过{{INDEX.index_field.name}}获取行数据对象
+    func get_item_by_{{INDEX.index_field.name}}({{INDEX.index_field.name}}) -> {{value_type_name}}:
+        return self._{{INDEX.index_field.name}}_data_map.get({{INDEX.index_field.name}})
+
+{{~ end ~}}
+    {{~else if table.is_list_table ~}}
+    var _data_list: Array[{{value_type_name}}] ## 数据数组
+    
+    func _init(_json_) -> void:
+        for _json2_ in _json_:
+            var _v: {{value_type_name}}
             {{deserialize '_v' '_json2_' value_type}}
             self._data_list.append(_v)
 
-    func get_data_list() -> Array : return self._data_list
-    func get_item(index) -> {{value_type_name}} : return self._data_list[index]
+    ## 获取数据数组
+    func get_data_list() -> Array[{{value_type_name}}]:
+        return self._data_list
+    
+    ## 通过序号获取行数据对象
+    func get_item(index) -> {{value_type_name}}:
+        return self._data_list[index]
     {{~else~}}
-    var _data: {{value_type_name}}
-    func _init(_json_):
-        assert(len(_json_) == 1, "table mode=one, but size != 1")
+    ## 单例数据对象
+    var _data:{{value_type_name}}
+    
+    func _init(_json_) -> void:
+        assert(len(_json_) == 1, "table mode = one, but size != 1")
         {{deserialize 'self._data' '_json_[0]' value_type}}
 
-    func get_data() -> {{value_type_name}} : return self._data
+    ## 获取单例数据对象
+    func get_data() -> {{value_type_name}}:
+        return self._data
 
     {{~ for field in value_type.def_bean.hierarchy_export_fields
      name = format_field_name __code_style field.name
      ~}}
 {{~if field.comment != '' ~}}
-    # {{escape_comment field.comment}}
+    ## {{escape_comment field.comment}}
 {{~end~}}
     var {{name}}: {{declaring_type_name field.ctype}}:
         get: return self._data.{{name}}
+
     {{~end~}}
     {{~end~}}
 
 {{~end~}}
-
-
+## 表格管理类：表格数据类组合而成，通过实例化此类进行各配置表数据的访问
 class {{str_full_name __full_name}}:
+    {{~for table in __tables ~}}
+    {{~if table.comment != ''~}}
+    ## {{table.comment | html.escape}}
+    {{~end~}}
+    var {{format_method_name __code_style table.name}}: {{full_name table}}
+    {{~end~}}
+    
+    func _init(loader: Callable) -> void:
         {{~for table in __tables ~}}
-    var {{format_method_name __code_style table.name}}: {{full_name table}} 
+        self.{{format_method_name __code_style table.name}} = {{full_name table}}.new(loader.call('{{table.output_data_file}}'))
         {{~end~}}
-    func _init(loader):
-        {{~for table in __tables ~}}
-        self.{{format_method_name __code_style table.name}} = {{full_name table}}.new(loader.call('{{table.output_data_file}}')); 
-        {{~end~}}
-        pass

--- a/src/Luban.Gdscript/TypeVisitors/UnderlyingDeserializeVisitor.cs
+++ b/src/Luban.Gdscript/TypeVisitors/UnderlyingDeserializeVisitor.cs
@@ -5,88 +5,10 @@ using Luban.TypeVisitors;
 
 namespace Luban.Gdscript.TypeVisitors;
 
-public class UnderlyingDeserializeVisitor : ITypeFuncVisitor<string, string, string>, ITypeFuncVisitor<string>
+public class UnderlyingDeserializeVisitor : ITypeFuncVisitor<string, string, string>
 {
     public static UnderlyingDeserializeVisitor Ins { get; } = new();
     
-    
-    public string Accept(TBool type)
-    {
-        return "bool";
-    }
-
-    public string Accept(TByte type)
-    {
-        return "int";
-    }
-
-    public string Accept(TShort type)
-    {
-        return "int";
-    }
-
-    public string Accept(TInt type)
-    {
-        return "int";
-    }
-
-    public string Accept(TLong type)
-    {
-        return "int";
-    }
-
-    public string Accept(TFloat type)
-    {
-        return "float";
-    }
-
-    public string Accept(TDouble type)
-    {
-        return "float";
-    }
-
-    public virtual string Accept(TEnum type)
-    {
-        // return GdscriptCommonTemplateExtension.FullName(type.DefEnum);
-        return "int";
-    }
-
-    public string Accept(TString type)
-    {
-        return "String";
-    }
-
-    public virtual string Accept(TDateTime type)
-    {
-        return "int";
-    }
-
-    public string Accept(TBean type)
-    {
-        return GdscriptCommonTemplateExtension.FullName(type.DefBean);
-    }
-
-    public string Accept(TArray type)
-    {
-        return $"Array[{type.ElementType.Apply((this))}]";
-    }
-
-    public string Accept(TList type)
-    {
-        return $"Array[{type.ElementType.Apply((this))}]";
-    }
-
-    public string Accept(TSet type)
-    {
-        return $"Array[{type.ElementType.Apply((this))}]";
-    }
-
-    public string Accept(TMap type)
-    {
-        return "Dictionary";
-    }
-    
-
     public string Accept(TBool type, string jsonVarName, string fieldName)
     {
         return $"{fieldName} = {jsonVarName}";
@@ -146,22 +68,22 @@ public class UnderlyingDeserializeVisitor : ITypeFuncVisitor<string, string, str
 
     public string Accept(TArray type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(this)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
+        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(DeclaringTypeNameVisitor.Ins)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
     }
 
     public string Accept(TList type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(this)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
+        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(DeclaringTypeNameVisitor.Ins)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
     }
 
     public string Accept(TSet type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(this)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
+        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(DeclaringTypeNameVisitor.Ins)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
     }
 
     public string Accept(TMap type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = {{}}\nfor _e in {jsonVarName}: var _k: {type.KeyType.Apply(this)}; {type.KeyType.Apply(this, "_e[0]", "_k")}; var _v: {type.ValueType.Apply(this)}; {type.ValueType.Apply(this, "_e[1]", "_v")}; {fieldName}[_k] = _v";
+        return $"{fieldName} = {{}}\nfor _e in {jsonVarName}: var _k: {type.KeyType.Apply(DeclaringTypeNameVisitor.Ins)}; {type.KeyType.Apply(this, "_e[0]", "_k")}; var _v: {type.ValueType.Apply(DeclaringTypeNameVisitor.Ins)}; {type.ValueType.Apply(this, "_e[1]", "_v")}; {fieldName}[_k] = _v";
     }
 
     public string Accept(TDateTime type, string jsonVarName, string fieldName)

--- a/src/Luban.Gdscript/TypeVisitors/UnderlyingDeserializeVisitor.cs
+++ b/src/Luban.Gdscript/TypeVisitors/UnderlyingDeserializeVisitor.cs
@@ -5,9 +5,87 @@ using Luban.TypeVisitors;
 
 namespace Luban.Gdscript.TypeVisitors;
 
-public class UnderlyingDeserializeVisitor : ITypeFuncVisitor<string, string, string>
+public class UnderlyingDeserializeVisitor : ITypeFuncVisitor<string, string, string>, ITypeFuncVisitor<string>
 {
     public static UnderlyingDeserializeVisitor Ins { get; } = new();
+    
+    
+    public string Accept(TBool type)
+    {
+        return "bool";
+    }
+
+    public string Accept(TByte type)
+    {
+        return "int";
+    }
+
+    public string Accept(TShort type)
+    {
+        return "int";
+    }
+
+    public string Accept(TInt type)
+    {
+        return "int";
+    }
+
+    public string Accept(TLong type)
+    {
+        return "int";
+    }
+
+    public string Accept(TFloat type)
+    {
+        return "float";
+    }
+
+    public string Accept(TDouble type)
+    {
+        return "float";
+    }
+
+    public virtual string Accept(TEnum type)
+    {
+        // return GdscriptCommonTemplateExtension.FullName(type.DefEnum);
+        return "int";
+    }
+
+    public string Accept(TString type)
+    {
+        return "String";
+    }
+
+    public virtual string Accept(TDateTime type)
+    {
+        return "int";
+    }
+
+    public string Accept(TBean type)
+    {
+        return GdscriptCommonTemplateExtension.FullName(type.DefBean);
+    }
+
+    public string Accept(TArray type)
+    {
+        return $"Array[{type.ElementType.Apply((this))}]";
+    }
+
+    public string Accept(TList type)
+    {
+        return $"Array[{type.ElementType.Apply((this))}]";
+    }
+
+    public string Accept(TSet type)
+    {
+        return $"Array[{type.ElementType.Apply((this))}]";
+    }
+
+    public string Accept(TMap type)
+    {
+        return "Dictionary";
+    }
+    
 
     public string Accept(TBool type, string jsonVarName, string fieldName)
     {
@@ -68,26 +146,27 @@ public class UnderlyingDeserializeVisitor : ITypeFuncVisitor<string, string, str
 
     public string Accept(TArray type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
+        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(this)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
     }
 
     public string Accept(TList type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
+        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(this)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
     }
 
     public string Accept(TSet type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
+        return $"{fieldName} = []\nfor _ele in {jsonVarName}: var _e: {type.ElementType.Apply(this)}; {type.ElementType.Apply(this, "_ele", "_e")}; {fieldName}.append(_e)";
     }
 
     public string Accept(TMap type, string jsonVarName, string fieldName)
     {
-        return $"{fieldName} = {{}}\nfor _e in {jsonVarName}: var _k; {type.KeyType.Apply(this, "_e[0]", "_k")}; var _v; {type.ValueType.Apply(this, "_e[1]", "_v")}; {fieldName}[_k] = _v";
+        return $"{fieldName} = {{}}\nfor _e in {jsonVarName}: var _k: {type.KeyType.Apply(this)}; {type.KeyType.Apply(this, "_e[0]", "_k")}; var _v: {type.ValueType.Apply(this)}; {type.ValueType.Apply(this, "_e[1]", "_v")}; {fieldName}[_k] = _v";
     }
 
     public string Accept(TDateTime type, string jsonVarName, string fieldName)
     {
         return $"{fieldName} = {jsonVarName}";
     }
+    
 }


### PR DESCRIPTION
gds版本优化
1、修复float值无法加入静态Array[int]的bug
2、尽可能增加静态类型标注，包括类成员以及静态Array的元素
3、增加独立多主键功能
4、优化了类/变量命名规则，尽量符合gds使用习惯
5、尽可能加入配置中的注释
6、优化输出scheme的排版