### PR TITLE
优化golang加载bin格式错误时的错误提示

### DIFF
--- a/src/Luban.Golang/Templates/go-bin/tables.sbn
+++ b/src/Luban.Golang/Templates/go-bin/tables.sbn
@@ -2,7 +2,10 @@
 package {{__namespace}};
 {{~end~}}
 
-import "{{__luban_module_name}}"
+import (
+    "{{__luban_module_name}}"
+    "errors"
+)
 
 type ByteBufLoader func(string) (*luban.ByteBuf, error)
 
@@ -22,7 +25,7 @@ func NewTables(loader ByteBufLoader) (*{{__name}}, error) {
         return nil, err
     }
     if tables.{{table.name}}, err = New{{full_name table}}(buf) ; err != nil {
-        return nil, err
+        return nil, errors.Join(errors.New("failed to load {{table.name}}"), err)
     }
     {{~end~}}
     return tables, nil


### PR DESCRIPTION
当前版本格式错误时提示信息不足以定位问题，增加了表名显示如下：

`err:failed to load ItemList\n_e_ error`