### PR TITLE
增加对CRLF的行尾符配置支持

### DIFF
--- a/src/Luban.Core/BuiltinOptionNames.cs
+++ b/src/Luban.Core/BuiltinOptionNames.cs
@@ -41,4 +41,6 @@ public static class BuiltinOptionNames
     public const string PathValidatorRootDir = "rootDir";
 
     public const string NamingConvention = "namingConvention";
+
+    public const string CodeLineEndingStyle = "codeLineEndingStyle";
 }

--- a/src/Luban.Core/CodeTarget/CodeWriter.cs
+++ b/src/Luban.Core/CodeTarget/CodeWriter.cs
@@ -28,7 +28,12 @@ public class CodeWriter
             sb.AppendLine(line);
         }
         sb.Replace("\r\n", "\n");
-        sb.Replace("\n\r", "\n");
+        sb.Replace("\r", "\n");
+        string lineEndingStyle = EnvManager.Current.GetOptionOrDefault(string.Empty, BuiltinOptionNames.CodeLineEndingStyle, true, string.Empty).ToUpper();
+        if (lineEndingStyle == "CRLF")
+        {
+            sb.Replace("\n", "\r\n");
+        }
         return sb.ToString();
     }
 }


### PR DESCRIPTION
默认还是LF, 命令行配置了之后才支持

例子:-x codeLineEndingStyle=CRLF ^