### PR TITLE
修复enum group无效的bug

### DIFF
--- a/src/Luban.Core/GenerationContext.cs
+++ b/src/Luban.Core/GenerationContext.cs
@@ -105,7 +105,7 @@ public class GenerationContext
                 {
                     TBean.Create(false, bean, null).Apply(RefTypeVisitor.Ins, refTypes);
                 }
-                else if (t is DefEnum)
+                else if (t is DefEnum && NeedExportNotDefault(t.Groups))
                 {
                     refTypes.Add(t.FullName, t);
                 }


### PR DESCRIPTION
修复了配置enum时，group值无效的bug。


![image](https://github.com/focus-creative-games/luban/assets/29481291/5b5e0c5d-2818-4284-92ad-5aa2d9441aec)
![image](https://github.com/focus-creative-games/luban/assets/29481291/9ea9736f-0c9a-4004-97a3-828641cb8763)
![image](https://github.com/focus-creative-games/luban/assets/29481291/a2afaff6-c082-4763-a0dd-7980e539103a)
