### PR TITLE
Fix the export of enum and bean. (Related to PR#119)

### DIFF
--- a/src/Luban.Core/GenerationContext.cs
+++ b/src/Luban.Core/GenerationContext.cs
@@ -97,7 +97,8 @@ public class GenerationContext
 
     private bool NeedExportNotDefault(List<string> groups)
     {
-        return groups.Any(Target.Groups.Contains);
+        // 如果没设置 groups 或者是 target groups
+        return groups.Count == 0 || groups.Any(Target.Groups.Contains);
     }
 
     private List<DefTypeBase> CalculateExportTypes()


### PR DESCRIPTION
PR #119 导致有些 `enum` 和 `bean` 没法导出。
`group` 都没有设置，奇怪的是有些 `enum` 和 `bean` 是能够导出的，有些则不能。原因未知。

由于是第一次使用 Luban, 如果是我理解不到位请指出，谢谢。
