### PR TITLE
[fix] cpp-bin 多维容器反序列化时为循环变量命名加上深度信息。

### DIFF
--- a/src/Luban.Core/TypeVisitors/ITypeFuncVisitor.cs
+++ b/src/Luban.Core/TypeVisitors/ITypeFuncVisitor.cs
@@ -133,3 +133,36 @@ public interface ITypeFuncVisitor<T, T2, T3, TR>
 
     TR Accept(TMap type, T x, T2 y, T3 z);
 }
+
+public interface ITypeFuncVisitor<T, T2, T3, T4, TR>
+{
+    TR Accept(TBool type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TByte type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TShort type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TInt type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TLong type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TFloat type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TDouble type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TEnum type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TString type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TDateTime type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TBean type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TArray type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TList type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TSet type, T x, T2 y, T3 z, T4 w);
+
+    TR Accept(TMap type, T x, T2 y, T3 z, T4 w);
+}

--- a/src/Luban.Core/Types/TArray.cs
+++ b/src/Luban.Core/Types/TArray.cs
@@ -78,4 +78,9 @@ public class TArray : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TBean.cs
+++ b/src/Luban.Core/Types/TBean.cs
@@ -59,4 +59,9 @@ public class TBean : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TBool.cs
+++ b/src/Luban.Core/Types/TBool.cs
@@ -51,4 +51,9 @@ public class TBool : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TByte.cs
+++ b/src/Luban.Core/Types/TByte.cs
@@ -49,4 +49,9 @@ public class TByte : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TDateTime.cs
+++ b/src/Luban.Core/Types/TDateTime.cs
@@ -50,4 +50,8 @@ public class TDateTime : TType
         return visitor.Accept(this, x, y, z);
     }
 
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TDouble.cs
+++ b/src/Luban.Core/Types/TDouble.cs
@@ -49,4 +49,9 @@ public class TDouble : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TEnum.cs
+++ b/src/Luban.Core/Types/TEnum.cs
@@ -56,4 +56,9 @@ public class TEnum : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TFloat.cs
+++ b/src/Luban.Core/Types/TFloat.cs
@@ -51,4 +51,9 @@ public class TFloat : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TInt.cs
+++ b/src/Luban.Core/Types/TInt.cs
@@ -49,4 +49,9 @@ public class TInt : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TList.cs
+++ b/src/Luban.Core/Types/TList.cs
@@ -68,4 +68,9 @@ public class TList : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TLong.cs
+++ b/src/Luban.Core/Types/TLong.cs
@@ -52,4 +52,9 @@ public class TLong : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TMap.cs
+++ b/src/Luban.Core/Types/TMap.cs
@@ -75,4 +75,9 @@ public class TMap : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TSet.cs
+++ b/src/Luban.Core/Types/TSet.cs
@@ -68,4 +68,9 @@ public class TSet : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TShort.cs
+++ b/src/Luban.Core/Types/TShort.cs
@@ -49,4 +49,9 @@ public class TShort : TType
     {
         return visitor.Accept(this, x, y, z);
     }
+
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TString.cs
+++ b/src/Luban.Core/Types/TString.cs
@@ -51,5 +51,8 @@ public class TString : TType
         return visitor.Accept(this, x, y, z);
     }
 
-
+    public override TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w)
+    {
+        return visitor.Accept(this, x, y, z, w);
+    }
 }

--- a/src/Luban.Core/Types/TType.cs
+++ b/src/Luban.Core/Types/TType.cs
@@ -59,4 +59,6 @@ public abstract class TType
     public abstract TR Apply<T1, T2, TR>(ITypeFuncVisitor<T1, T2, TR> visitor, T1 x, T2 y);
 
     public abstract TR Apply<T1, T2, T3, TR>(ITypeFuncVisitor<T1, T2, T3, TR> visitor, T1 x, T2 y, T3 z);
+
+    public abstract TR Apply<T1, T2, T3, T4, TR>(ITypeFuncVisitor<T1, T2, T3, T4, TR> visitor, T1 x, T2 y, T3 z, T4 w);
 }

--- a/src/Luban.Cpp/TemplateExtensions/CppRawptrBinTemplateExtension.cs
+++ b/src/Luban.Cpp/TemplateExtensions/CppRawptrBinTemplateExtension.cs
@@ -8,7 +8,7 @@ public class CppRawptrBinTemplateExtension : ScriptObject
 {
     public static string Deserialize(string bufName, string fieldName, TType type)
     {
-        return type.Apply(CppRawptrDeserializeVisitor.Ins, bufName, fieldName);
+        return type.Apply(CppRawptrDeserializeVisitor.Ins, bufName, fieldName, 0);
     }
 
     public static string DeclaringTypeName(TType type)

--- a/src/Luban.Cpp/TemplateExtensions/CppSharedptrBinTemplateExtension.cs
+++ b/src/Luban.Cpp/TemplateExtensions/CppSharedptrBinTemplateExtension.cs
@@ -8,7 +8,7 @@ public class CppSharedptrBinTemplateExtension : ScriptObject
 {
     public static string Deserialize(string bufName, string fieldName, TType type)
     {
-        return type.Apply(CppSharedptrDeserializeVisitor.Ins, bufName, fieldName);
+        return type.Apply(CppSharedptrDeserializeVisitor.Ins, bufName, fieldName,0);
     }
 
     public static string DeclaringTypeName(TType type)

--- a/src/Luban.Cpp/TypeVisitors/CppRawptrDeserializeVisitor.cs
+++ b/src/Luban.Cpp/TypeVisitors/CppRawptrDeserializeVisitor.cs
@@ -3,19 +3,19 @@ using Luban.TypeVisitors;
 
 namespace Luban.Cpp.TypeVisitors;
 
-public class CppRawptrDeserializeVisitor : DecoratorFuncVisitor<string, string, string>
+public class CppRawptrDeserializeVisitor : DecoratorFuncVisitor<string, string, int, string>
 {
     public static CppRawptrDeserializeVisitor Ins { get; } = new CppRawptrDeserializeVisitor();
 
-    public override string DoAccept(TType type, string bufName, string fieldName)
+    public override string DoAccept(TType type, string bufName, string fieldName, int depth)
     {
         if (type.IsNullable)
         {
-            return $"{{ bool _has_value_; if(!{bufName}.readBool(_has_value_)){{return false;}}  if(_has_value_) {{ {fieldName} = {(type.IsBean ? "nullptr" : $"new {type.Apply(CppUnderlyingDeclaringTypeNameVisitor.Ins)}{{}}")}; {type.Apply(CppRawptrUnderlyingDeserializeVisitor.Ins, bufName, type.IsBean ? fieldName : $"*{fieldName}", CppRawptrDeclaringTypeNameVisitor.Ins)} }} else {{ {fieldName} = nullptr; }} }}";
+            return $"{{ bool _has_value_; if(!{bufName}.readBool(_has_value_)){{return false;}}  if(_has_value_) {{ {fieldName} = {(type.IsBean ? "nullptr" : $"new {type.Apply(CppUnderlyingDeclaringTypeNameVisitor.Ins)}{{}}")}; {type.Apply(CppRawptrUnderlyingDeserializeVisitor.Ins, bufName, type.IsBean ? fieldName : $"*{fieldName}",depth + 1, CppRawptrDeclaringTypeNameVisitor.Ins)} }} else {{ {fieldName} = nullptr; }} }}";
         }
         else
         {
-            return type.Apply(CppRawptrUnderlyingDeserializeVisitor.Ins, bufName, fieldName, CppRawptrDeclaringTypeNameVisitor.Ins);
+            return type.Apply(CppRawptrUnderlyingDeserializeVisitor.Ins, bufName, fieldName, depth, CppRawptrDeclaringTypeNameVisitor.Ins);
         }
     }
 }

--- a/src/Luban.Cpp/TypeVisitors/CppSharedptrDeserializeVisitor.cs
+++ b/src/Luban.Cpp/TypeVisitors/CppSharedptrDeserializeVisitor.cs
@@ -3,19 +3,19 @@ using Luban.TypeVisitors;
 
 namespace Luban.Cpp.TypeVisitors;
 
-public class CppSharedptrDeserializeVisitor : DecoratorFuncVisitor<string, string, string>
+public class CppSharedptrDeserializeVisitor : DecoratorFuncVisitor<string, string, int, string>
 {
     public static CppSharedptrDeserializeVisitor Ins { get; } = new CppSharedptrDeserializeVisitor();
 
-    public override string DoAccept(TType type, string bufName, string fieldName)
+    public override string DoAccept(TType type, string bufName, string fieldName, int depth)
     {
         if (type.IsNullable)
         {
-            return $"{{ bool _has_value_; if(!{bufName}.readBool(_has_value_)){{return false;}}  if(_has_value_) {{ {fieldName}.reset({(type.IsBean ? "" : $"new {type.Apply(CppUnderlyingDeclaringTypeNameVisitor.Ins)}()")}); {type.Apply(CppSharedptrUnderlyingDeserializeVisitor.Ins, bufName, $"{(type.IsBean ? "" : "*")}{fieldName}", CppSharedptrDeclaringTypeNameVisitor.Ins)} }} else {{ {fieldName}.reset(); }} }}";
+            return $"{{ bool _has_value_; if(!{bufName}.readBool(_has_value_)){{return false;}}  if(_has_value_) {{ {fieldName}.reset({(type.IsBean ? "" : $"new {type.Apply(CppUnderlyingDeclaringTypeNameVisitor.Ins)}()")}); {type.Apply(CppSharedptrUnderlyingDeserializeVisitor.Ins, bufName, $"{(type.IsBean ? "" : "*")}{fieldName}",depth+1, CppSharedptrDeclaringTypeNameVisitor.Ins)} }} else {{ {fieldName}.reset(); }} }}";
         }
         else
         {
-            return type.Apply(CppSharedptrUnderlyingDeserializeVisitor.Ins, bufName, fieldName, CppSharedptrDeclaringTypeNameVisitor.Ins);
+            return type.Apply(CppSharedptrUnderlyingDeserializeVisitor.Ins, bufName, fieldName, depth ,CppSharedptrDeclaringTypeNameVisitor.Ins);
         }
     }
 }

--- a/src/Luban.Cpp/TypeVisitors/CppUnderlyingDeserializeVisitorBase.cs
+++ b/src/Luban.Cpp/TypeVisitors/CppUnderlyingDeserializeVisitorBase.cs
@@ -4,80 +4,84 @@ using Luban.TypeVisitors;
 
 namespace Luban.Cpp.TypeVisitors;
 
-public abstract class CppUnderlyingDeserializeVisitorBase : ITypeFuncVisitor<string, string, ITypeFuncVisitor<string>, string>
+public abstract class CppUnderlyingDeserializeVisitorBase : ITypeFuncVisitor<string, string, int, ITypeFuncVisitor<string>, string>
 {
-    public string Accept(TBool type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TBool type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if (!{bufName}.readBool({fieldName})) return false;";
     }
 
-    public string Accept(TByte type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TByte type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readByte({fieldName})) return false;";
     }
 
-    public string Accept(TShort type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TShort type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readShort({fieldName})) return false;";
     }
 
-    public string Accept(TInt type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TInt type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readInt({fieldName})) return false;";
     }
 
-    public string Accept(TLong type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TLong type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readLong({fieldName})) return false;";
     }
 
-    public string Accept(TFloat type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TFloat type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readFloat({fieldName})) return false;";
     }
 
-    public string Accept(TDouble type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TDouble type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readDouble({fieldName})) return false;";
     }
 
-    public string Accept(TEnum type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TEnum type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"{{int __enum_temp__; if(!{bufName}.readInt(__enum_temp__)) return false; {fieldName} = {CppTemplateExtension.MakeTypeCppName(type.DefEnum)}(__enum_temp__); }}";
     }
 
-    public string Accept(TString type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TString type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readString({fieldName})) return false;";
     }
 
-    public string Accept(TBean type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TBean type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{CppTemplateExtension.MakeTypeCppName(type.DefBean)}::deserialize{type.DefBean.Name}({bufName}, {fieldName})) return false;";
     }
 
-    public string Accept(TDateTime type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TDateTime type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
         return $"if(!{bufName}.readLong({fieldName})) return false;";
     }
 
-    public string Accept(TArray type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TArray type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
-        return $"{{::luban::int32 n; if(!{bufName}.readSize(n)) return false; n = std::min(n, ::luban::int32({bufName}.size()));{fieldName}.reserve(n);for(int i = 0 ; i < n ; i++) {{ {type.ElementType.Apply(typeVisitor)} _e; {type.ElementType.Apply(this, bufName, "_e", typeVisitor)} {fieldName}.push_back(_e);}}}}";
+        var suffix = depth == 0 ? "" : $"_{depth}";
+        return $"{{::luban::int32 n{suffix}; if(!{bufName}.readSize(n{suffix})) return false; n{suffix} = std::min(n{suffix}, ::luban::int32({bufName}.size())); {fieldName}.reserve(n{suffix});for(int i{suffix} = 0 ; i{suffix} < n{suffix} ; i{suffix}++) {{ {type.ElementType.Apply(typeVisitor)} _e{suffix}; {type.ElementType.Apply(this, bufName, $"_e{suffix}", depth + 1, typeVisitor)} {fieldName}.push_back(_e{suffix});}}}}";
     }
 
-    public string Accept(TList type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TList type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
-        return $"{{::luban::int32 n; if(!{bufName}.readSize(n)) return false; n = std::min(n, ::luban::int32({bufName}.size())); {fieldName}.reserve(n);for(int i = 0 ; i < n ; i++) {{ {type.ElementType.Apply(typeVisitor)} _e; {type.ElementType.Apply(this, bufName, "_e", typeVisitor)} {fieldName}.push_back(_e);}}}}";
+        var suffix = depth == 0 ? "" : $"_{depth}";
+        return $"{{::luban::int32 n{suffix}; if(!{bufName}.readSize(n{suffix})) return false; n{suffix} = std::min(n{suffix}, ::luban::int32({bufName}.size())); {fieldName}.reserve(n{suffix});for(int i{suffix} = 0 ; i{suffix} < n{suffix} ; i{suffix}++) {{ {type.ElementType.Apply(typeVisitor)} _e{suffix}; {type.ElementType.Apply(this, bufName, $"_e{suffix}", depth + 1, typeVisitor)} {fieldName}.push_back(_e{suffix});}}}}";
     }
 
-    public string Accept(TSet type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TSet type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
-        return $"{{::luban::int32 n; if(!{bufName}.readSize(n)) return false; n = std::min(n, ::luban::int32({bufName}.size())); {fieldName}.reserve(n * 3 / 2);for(int i = 0 ; i < n ; i++) {{ {type.ElementType.Apply(typeVisitor)} _e; {type.ElementType.Apply(this, bufName, "_e", typeVisitor)} {fieldName}.insert(_e);}}}}";
+        var suffix = depth == 0 ? "" : $"_{depth}";
+        return $"{{::luban::int32 n{suffix}; if(!{bufName}.readSize(n{suffix})) return false; n{suffix} = std::min(n{suffix}, ::luban::int32({bufName}.size())); {fieldName}.reserve(n{suffix} * 3 / 2);for(int i{suffix} = 0 ; i{suffix} < n{suffix} ; i{suffix}++) {{ {type.ElementType.Apply(typeVisitor)} _e{suffix}; {type.ElementType.Apply(this, bufName, $"_e{suffix}", depth + 1, typeVisitor)} {fieldName}.insert(_e{suffix});}}}}";
     }
 
-    public string Accept(TMap type, string bufName, string fieldName, ITypeFuncVisitor<string> typeVisitor)
+    public string Accept(TMap type, string bufName, string fieldName, int depth, ITypeFuncVisitor<string> typeVisitor)
     {
-        return $"{{::luban::int32 n; if(!{bufName}.readSize(n)) return false; n = std::min(n, (::luban::int32){bufName}.size()); {fieldName}.reserve(n * 3 / 2);for(int i = 0 ; i < n ; i++) {{ {type.KeyType.Apply(typeVisitor)} _k; {type.KeyType.Apply(this, bufName, "_k", typeVisitor)} {type.ValueType.Apply(typeVisitor)} _v; {type.ValueType.Apply(this, bufName, "_v", typeVisitor)} {fieldName}[_k] = _v;}}}}";
+        var suffix = depth == 0 ? "" : $"_{depth}";
+        return $"{{::luban::int32 n{suffix}; if(!{bufName}.readSize(n{suffix})) return false; n{suffix} = std::min(n{suffix}, (::luban::int32){bufName}.size()); {fieldName}.reserve(n{suffix} * 3 / 2);for(int i{suffix} = 0 ; i{suffix} < n{suffix} ; i{suffix}++) {{ {type.KeyType.Apply(typeVisitor)} _k{suffix}; {type.KeyType.Apply(this, bufName, $"_k{suffix}", depth + 1, typeVisitor)} {type.ValueType.Apply(typeVisitor)} _v{suffix}; {type.ValueType.Apply(this, bufName, $"_v{suffix}",depth + 1, typeVisitor)} {fieldName}[_k{suffix}] = _v{suffix};}}}}";
     }
 }


### PR DESCRIPTION
cpp-*-bin 反序列化容器时，都是用的 `i`,`n`,`_e`,`_k`,`_v`变量名。如果容器嵌套，变量名会冲突。
这个问题和 #122 类似，相信其他语言前端也有。

这里给一个解决方案：当嵌套深度大于0时，给这些变量名加上 `_{depth}` 后辍。
