### PR TITLE
[fix] typescript template

### DIFF
--- a/src/Luban.Typescript/Templates/typescript-json/schema.sbn
+++ b/src/Luban.Typescript/Templates/typescript-json/schema.sbn
@@ -41,9 +41,9 @@ func generate_resolve_field_ref
         if (is_field_bean_need_resolve_ref field)
             ret 'this.'+fieldName + '?.resolve(tables);'
         else if (is_field_array_like_need_resolve_ref field)
-            ret 'for (let _e of ' + 'this.' + + fieldName + ') { _e?.resolve(tables); }'
+            ret 'for (let _e of ' + 'this.' + fieldName + ') { _e?.resolve(tables); }'
         else if (is_field_map_need_resolve_ref field)
-            ret 'foreach (var [_, _e] of ' + 'this.' + fieldName ') { _e?.resolve(tables); }'
+            ret 'for (let [_, _e] of ' + 'this.' + fieldName + ') { _e?.resolve(tables); }'
         else
             ret ''
         end


### PR DESCRIPTION
修几个ts模板和语法的问题：
1. 由  [commit 88c09b](https://github.com/focus-creative-games/luban/commit/88c09bcbf2769b8e3fb69b5fa7ec18ff84898e39) 引入两个 `+` 模板报错：
```
ret 'for (let _e of ' + 'this.' + + fieldName + ') { _e?.resolve(tables); }'

|ERROR|===> "One or more errors occurred. (<input>(44,49) : error : Unexpected value `keys / Type: string`. Cannot negate(-)/positive(+) a non-numeric value)"
|ERROR|===> "<input>(44,49) : error : Unexpected value `keys / Type: string`. Cannot negate(-)/positive(+) a non-numeric value"
|ERROR|run failed!!!
```
2. 最初这段末尾少一个 `+` 模板报错 [commit 3d1fae](https://github.com/focus-creative-games/luban/commit/3d1faed5deb02035ce5c4d281a71b3e24f6d739f)  
```
ret 'foreach (var [_, _e] of ' + fieldName ') { _e?.resolve(tables); }'

|ERROR|===> "One or more errors occurred. (<input>(46,52) : error : Invalid target function `multiRows4` (string))"
|ERROR|===> "<input>(46,52) : error : Invalid target function `multiRows4` (string)"
|ERROR|run failed!!!
```
3. typescript 没有 foreach 关键字，对 map 的迭代也用 for
4. 用 let 替换 var，减小scope