### PR TITLE
新增自定义data扩展名的命令行选项

### DIFF
--- a/src/Luban.Bson/BsonDataTarget.cs
+++ b/src/Luban.Bson/BsonDataTarget.cs
@@ -8,7 +8,7 @@ namespace Luban.Bson;
 [DataTarget("bson")]
 public class BsonDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "bson";
+    protected override string DefaultOutputFileExt => "bson";
 
 
     private void WriteAsArray(List<Record> datas, BsonDataWriter x)

--- a/src/Luban.Core/BuiltinOptionNames.cs
+++ b/src/Luban.Core/BuiltinOptionNames.cs
@@ -8,6 +8,10 @@ public static class BuiltinOptionNames
 
     public const string OutputDataDir = "outputDataDir";
 
+    public const string OutputCodeExtension = "outputCodeExtension";
+
+    public const string OutputDataExtension = "outputDataExtension";
+
     public const string CodeStyle = "codeStyle";
 
     public const string DataExporter = "dataExporter";

--- a/src/Luban.Core/DataTarget/DataTargetBase.cs
+++ b/src/Luban.Core/DataTarget/DataTargetBase.cs
@@ -1,4 +1,5 @@
 using Luban.Defs;
+using System.Reflection;
 
 namespace Luban.DataTarget;
 
@@ -10,7 +11,29 @@ public abstract class DataTargetBase : IDataTarget
 
     public virtual bool ExportAllRecords => false;
 
-    protected abstract string OutputFileExt { get; }
+    protected abstract string DefaultOutputFileExt { get; }
+
+    protected string OutputFileExt { get; }
+
+    protected DataTargetBase()
+    {
+        OutputFileExt = DefaultOutputFileExt;
+        var dataTargetAttr = GetType().GetCustomAttribute<DataTargetAttribute>();
+        if (dataTargetAttr == null)
+        {
+            return;
+        }
+
+        var namespaze = dataTargetAttr.Name;
+        var optionName = BuiltinOptionNames.OutputDataExtension;
+        if (EnvManager.Current.TryGetOption(namespaze, optionName, false, out var optionExt))
+        {
+            if (!string.IsNullOrWhiteSpace(optionExt))
+            {
+                OutputFileExt = optionExt;
+            }
+        }
+    }
 
     public abstract OutputFile ExportTable(DefTable table, List<Record> records);
 
@@ -23,4 +46,5 @@ public abstract class DataTargetBase : IDataTarget
     {
         throw new NotSupportedException();
     }
+
 }

--- a/src/Luban.DataTarget.Builtin/Binary/BinaryDataTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Binary/BinaryDataTarget.cs
@@ -7,7 +7,7 @@ namespace Luban.DataExporter.Builtin.Binary;
 [DataTarget("bin")]
 public class BinaryDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "bytes";
+    protected override string DefaultOutputFileExt => "bytes";
 
     private void WriteList(DefTable table, List<Record> datas, ByteBuf x)
     {

--- a/src/Luban.DataTarget.Builtin/Binary/BinaryRecordOffsetDataTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Binary/BinaryRecordOffsetDataTarget.cs
@@ -8,7 +8,7 @@ namespace Luban.DataExporter.Builtin.Binary;
 [DataTarget("bin-offset")]
 public class BinaryRecordOffsetDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "bytes";
+    protected override string DefaultOutputFileExt => "bytes";
 
     private void WriteList(DefTable table, List<Record> datas, ByteBuf x)
     {

--- a/src/Luban.DataTarget.Builtin/Json/Json2DataTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Json/Json2DataTarget.cs
@@ -9,7 +9,7 @@ namespace Luban.DataExporter.Builtin.Json;
 [DataTarget("json2")]
 public class Json2DataTarget : JsonDataTarget
 {
-    protected override string OutputFileExt => "json";
+    protected override string DefaultOutputFileExt => "json";
 
     private void WriteAsObject(DefTable table, List<Record> datas, Utf8JsonWriter x)
     {

--- a/src/Luban.DataTarget.Builtin/Json/JsonConvertTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Json/JsonConvertTarget.cs
@@ -9,7 +9,7 @@ namespace Luban.DataExporter.Builtin.Json;
 [DataTarget("json-convert")]
 public class JsonConvertTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "json";
+    protected override string DefaultOutputFileExt => "json";
 
     public static bool UseCompactJson => EnvManager.Current.GetBoolOptionOrDefault("json", "compact", true, false);
 

--- a/src/Luban.DataTarget.Builtin/Json/JsonDataTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Json/JsonDataTarget.cs
@@ -8,7 +8,7 @@ namespace Luban.DataExporter.Builtin.Json;
 [DataTarget("json")]
 public class JsonDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "json";
+    protected override string DefaultOutputFileExt => "json";
 
     public static bool UseCompactJson => EnvManager.Current.GetBoolOptionOrDefault("json", "compact", true, false);
 

--- a/src/Luban.DataTarget.Builtin/Xml/XmlDataTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Xml/XmlDataTarget.cs
@@ -10,7 +10,7 @@ namespace Luban.DataExporter.Builtin.Xml;
 [DataTarget("xml")]
 public class XmlDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "xml";
+    protected override string DefaultOutputFileExt => "xml";
 
     public void WriteAsArray(List<Record> datas, XmlWriter w)
     {

--- a/src/Luban.DataTarget.Builtin/Yaml/YamlDataTarget.cs
+++ b/src/Luban.DataTarget.Builtin/Yaml/YamlDataTarget.cs
@@ -8,7 +8,7 @@ namespace Luban.DataExporter.Builtin.Yaml;
 [DataTarget("yaml")]
 public class YamlDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "yml";
+    protected override string DefaultOutputFileExt => "yml";
 
     public YamlNode WriteAsArray(List<Record> datas)
     {

--- a/src/Luban.FlatBuffers/DataTarget/FlatBuffersDataTarget.cs
+++ b/src/Luban.FlatBuffers/DataTarget/FlatBuffersDataTarget.cs
@@ -10,7 +10,7 @@ namespace Luban.FlatBuffers.DataTarget;
 [DataTarget("flatbuffers-json")]
 public class FlatBuffersDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "json";
+    protected override string DefaultOutputFileExt => "json";
 
     private void WriteAsTable(List<Record> datas, Utf8JsonWriter x)
     {

--- a/src/Luban.L10N/DataTarget/TextKeyListDataTarget.cs
+++ b/src/Luban.L10N/DataTarget/TextKeyListDataTarget.cs
@@ -7,7 +7,7 @@ namespace Luban.L10N.DataTarget;
 [DataTarget("text-list")]
 internal class TextKeyListDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "txt";
+    protected override string DefaultOutputFileExt => "txt";
 
     public override bool ExportAllRecords => true;
 

--- a/src/Luban.Lua/DataTarget/LuaDataTarget.cs
+++ b/src/Luban.Lua/DataTarget/LuaDataTarget.cs
@@ -50,7 +50,7 @@ public class LuaDataTarget : DataTargetBase
         s.Append('}');
     }
 
-    protected override string OutputFileExt => "lua";
+    protected override string DefaultOutputFileExt => "lua";
 
     public override OutputFile ExportTable(DefTable table, List<Record> records)
     {

--- a/src/Luban.MsgPack/MsgPackDataTarget.cs
+++ b/src/Luban.MsgPack/MsgPackDataTarget.cs
@@ -9,7 +9,7 @@ namespace Luban.MsgPack;
 [DataTarget("msgpack")]
 public class MsgPackDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "bytes";
+    protected override string DefaultOutputFileExt => "bytes";
 
 
     public void WriteList(DefTable table, List<Record> records, ref MessagePackWriter writer)

--- a/src/Luban.Protobuf/DataTarget/ProtobufBinDataTarget.cs
+++ b/src/Luban.Protobuf/DataTarget/ProtobufBinDataTarget.cs
@@ -9,7 +9,7 @@ namespace Luban.Protobuf.DataTarget;
 [DataTarget("protobuf-bin")]
 public class ProtobufBinDataTarget : DataTargetBase
 {
-    protected override string OutputFileExt => "bytes";
+    protected override string DefaultOutputFileExt => "bytes";
 
     public void WriteList(DefTable table, List<Record> datas, MemoryStream x)
     {

--- a/src/Luban.Protobuf/DataTarget/ProtobufJsonDataTarget.cs
+++ b/src/Luban.Protobuf/DataTarget/ProtobufJsonDataTarget.cs
@@ -10,7 +10,7 @@ namespace Luban.Protobuf.DataTarget;
 [DataTarget("protobuf-json")]
 public class ProtobufJsonDataTarget : JsonDataTarget
 {
-    protected override string OutputFileExt => "json";
+    protected override string DefaultOutputFileExt => "json";
 
     protected override JsonDataVisitor ImplJsonDataVisitor => ProtobufJsonDataVisitor.Ins;
 


### PR DESCRIPTION
使用方式，添加如下命令行：
``` Batch
   -x <data_target_name>.outputDataExtension=<custom_name>
````

举例：
``` Batch
-t server 
-c cs-dotnet-json 
-d json  
--conf ..\..\DataTables\luban.conf 
-x outputCodeDir=Gen 
-x outputDataDir=..\GenerateDatas\json 
-x json.outputDataExtension=jason
-x pathValidator.rootDir=D:\workspace2\luban_examples\Projects\Csharp_Unity_bin 
``` 

最终会输出后缀名为".jason"的数据文件。