### PR TITLE
[fix] 修复了refgroup只会检查第一个表的bug

### DIFF
--- a/src/Luban.CSharp/TemplateExtensions/CsharpTemplateExtension.cs
+++ b/src/Luban.CSharp/TemplateExtensions/CsharpTemplateExtension.cs
@@ -19,6 +19,11 @@ public class CsharpTemplateExtension : ScriptObject
         return type.Apply(DeclaringCollectionRefNameVisitor.Ins);
     }
 
+    public static string DeclaringCollectionRefNameFromRefGroup(TType type, int index)
+    {
+        return type.Apply(DeclaringCollectionRefNameFromRefGroupVisitor.Ins, index);
+    }
+
     public static string ClassOrStruct(DefBean bean)
     {
         return bean.IsValueType ? "struct" : "class";

--- a/src/Luban.CSharp/Templates/cs-bin/bean.sbn
+++ b/src/Luban.CSharp/Templates/cs-bin/bean.sbn
@@ -16,6 +16,10 @@ func get_ref_name
     ret (format_property_name __code_style $0.name) + '_Ref'
 end
 
+func get_ref_name_with_table_name
+    ret (format_property_name __code_style $0.name) + '_Ref_' + format_property_name __code_style $1
+end
+
 func get_index_var_name
     ret (format_property_name __code_style $0.name) + '_Index'
 end
@@ -49,6 +53,36 @@ func generate_resolve_field_ref
 		else
 			ret ''
 		end
+    else if can_generate_ref_group field
+        index = $1
+        refTables = get_ref_tables_from_ref_group field
+        refTable = refTables[index]
+        tableName = format_property_name __code_style refTable.name
+        if field.is_nullable
+            ret (get_ref_name_with_table_name field refTable.name) + ' = ' + fieldName + '!= null ? tables.' + tableName + '.GetOrDefault(' + (get_value_of_nullable_type field.ctype fieldName) + ') : null;'
+        else
+            ret (get_ref_name_with_table_name field refTable.name) + ' = tables.' + tableName + '.GetOrDefault(' + fieldName + ');'
+        end
+    else if can_generate_collection_ref_group field
+        index = $1
+        ref_tables = get_collection_ref_tables_from_ref_group field
+        ref_table = ref_tables[index]
+        tableName = format_property_name __code_style ref_table.name
+        if field.ctype.type_name == 'list' || field.ctype.type_name == 'set'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_collection_ref_name_from_ref_group field.ctype index) + '();' + '\n'
+            line2 = 'foreach (var _v in ' + fieldName + ') { ' + (get_ref_name_with_table_name field ref_table.name) + '.Add(tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
+            ret line1 + line2
+        else if field.ctype.type_name == 'array'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_type_name ref_table.value_ttype) + '[' + fieldName + '.Length];' + '\n'
+            line2 = 'for (int _i = 0; _i < ' + fieldName + '.Length; _i++) { ' + (get_ref_name_with_table_name field ref_table.name) + '[_i] = tables.' + tableName + '.GetOrDefault(' + fieldName + '[_i]); }' + '\n'
+            ret line1 + line2
+        else if field.ctype.type_name == 'map'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_collection_ref_name_from_ref_group field.ctype index) + '();' + '\n'
+            line2 = 'foreach (var (_k,_v) in ' + fieldName + ') { ' + (get_ref_name_with_table_name field ref_table.name) + '.Add(_k, tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
+            ret line1 + line2
+        else
+            ret ''
+        end
     else
         if (is_field_bean_need_resolve_ref field)
             ret fieldName + '?.ResolveRef(tables);'
@@ -112,6 +146,14 @@ public {{class_modifier __bean}} partial class {{__name}} : {{if parent_def_type
     public {{declaring_type_name (get_ref_type field)}} {{get_ref_name field}};
     {{~else if can_generate_collection_ref field~}}
     public {{declaring_collection_ref_name field.ctype}} {{get_ref_name field}};
+    {{~else if can_generate_ref_group field~}}
+        {{~for ref_table in (get_ref_tables_from_ref_group field)~}}
+    public {{declaring_type_name ref_table.value_ttype}} {{get_ref_name_with_table_name field ref_table.name}};
+        {{~end~}}
+    {{~else if can_generate_collection_ref_group field~}}
+        {{~for ref_table in (get_collection_ref_tables_from_ref_group field)~}}
+    public {{declaring_collection_ref_name_from_ref_group field.ctype for.index}} {{get_ref_name_with_table_name field ref_table.name}};
+        {{~end~}}
     {{~end~}}
    {{~if has_index field
         indexMapType = get_index_map_type field
@@ -131,7 +173,13 @@ public {{class_modifier __bean}} partial class {{__name}} : {{if parent_def_type
         base.ResolveRef(tables);
         {{~end~}}
         {{~for field in export_fields~}}
+            {{~if has_ref_group field~}}
+                {{~for index in 0..((get_ref_group_tables_count field) - 1)~}}
+        {{generate_resolve_field_ref field index}}
+                {{~end~}}
+            {{~else~}}
         {{generate_resolve_field_ref field}}
+            {{~end~}}
         {{~end~}}
     }
 

--- a/src/Luban.CSharp/Templates/cs-dotnet-json/bean.sbn
+++ b/src/Luban.CSharp/Templates/cs-dotnet-json/bean.sbn
@@ -17,6 +17,10 @@ func get_ref_name
     ret (format_property_name __code_style $0.name) + '_Ref'
 end
 
+func get_ref_name_with_table_name
+    ret (format_property_name __code_style $0.name) + '_Ref_' + format_property_name __code_style $1
+end
+
 func get_index_var_name
     ret (format_property_name __code_style $0.name) + '_Index'
 end
@@ -47,6 +51,36 @@ func generate_resolve_field_ref
             line1 = (get_ref_name field) + ' = new ' + (declaring_collection_ref_name field.ctype) + '();' + '\n'
 			line2 = 'foreach (var (_k,_v) in ' + fieldName + ') { ' + (get_ref_name field) + '.Add(_k, tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
 			ret line1 + line2
+        else
+			ret ''
+		end
+    else if can_generate_ref_group field
+        index = $1
+        refTables = get_ref_tables_from_ref_group field
+        refTable = refTables[index]
+        tableName = format_property_name __code_style refTable.name
+        if field.is_nullable
+            ret (get_ref_name_with_table_name field refTable.name) + ' = ' + fieldName + '!= null ? tables.' + tableName + '.GetOrDefault(' + (get_value_of_nullable_type field.ctype fieldName) + ') : null;'
+        else
+            ret (get_ref_name_with_table_name field refTable.name) + ' = tables.' + tableName + '.GetOrDefault(' + fieldName + ');'
+        end
+    else if can_generate_collection_ref_group field
+        index = $1
+        ref_tables = get_collection_ref_tables_from_ref_group field
+        ref_table = ref_tables[index]
+        tableName = format_property_name __code_style ref_table.name
+        if field.ctype.type_name == 'list' || field.ctype.type_name == 'set'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_collection_ref_name_from_ref_group field.ctype index) + '();' + '\n'
+            line2 = 'foreach (var _v in ' + fieldName + ') { ' + (get_ref_name_with_table_name field ref_table.name) + '.Add(tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
+            ret line1 + line2
+        else if field.ctype.type_name == 'array'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_type_name ref_table.value_ttype) + '[' + fieldName + '.Length];' + '\n'
+            line2 = 'for (int _i = 0; _i < ' + fieldName + '.Length; _i++) { ' + (get_ref_name_with_table_name field ref_table.name) + '[_i] = tables.' + tableName + '.GetOrDefault(' + fieldName + '[_i]); }' + '\n'
+            ret line1 + line2
+        else if field.ctype.type_name == 'map'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_collection_ref_name_from_ref_group field.ctype index) + '();' + '\n'
+            line2 = 'foreach (var (_k,_v) in ' + fieldName + ') { ' + (get_ref_name_with_table_name field ref_table.name) + '.Add(_k, tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
+            ret line1 + line2
 		else
 			ret ''
 		end
@@ -113,6 +147,14 @@ public {{class_modifier __bean}} partial class {{__name}} : {{if parent_def_type
     public {{declaring_type_name (get_ref_type field)}} {{get_ref_name field}};
     {{~else if can_generate_collection_ref field~}}
     public {{declaring_collection_ref_name field.ctype}} {{get_ref_name field}};
+    {{~else if can_generate_ref_group field~}}
+        {{~for ref_table in (get_ref_tables_from_ref_group field)~}}
+    public {{declaring_type_name ref_table.value_ttype}} {{get_ref_name_with_table_name field ref_table.name}};
+        {{~end~}}
+    {{~else if can_generate_collection_ref_group field~}}
+        {{~for ref_table in (get_collection_ref_tables_from_ref_group field)~}}
+    public {{declaring_collection_ref_name_from_ref_group field.ctype for.index}} {{get_ref_name_with_table_name field ref_table.name}};
+        {{~end~}}
     {{~end~}}
    {{~if has_index field
         indexMapType = get_index_map_type field
@@ -132,7 +174,13 @@ public {{class_modifier __bean}} partial class {{__name}} : {{if parent_def_type
         base.ResolveRef(tables);
         {{~end~}}
         {{~for field in export_fields~}}
+            {{~if has_ref_group field~}}
+                {{~for index in 0..((get_ref_group_tables_count field) - 1)~}}
+        {{generate_resolve_field_ref field index}}
+                {{~end~}}
+            {{~else~}}
         {{generate_resolve_field_ref field}}
+            {{~end~}}
         {{~end~}}
     }
 

--- a/src/Luban.CSharp/Templates/cs-simple-json/bean.sbn
+++ b/src/Luban.CSharp/Templates/cs-simple-json/bean.sbn
@@ -17,6 +17,10 @@ func get_ref_name
     ret (format_property_name __code_style $0.name) + '_Ref'
 end
 
+func get_ref_name_with_table_name
+    ret (format_property_name __code_style $0.name) + '_Ref_' + format_property_name __code_style $1
+end
+
 func get_index_var_name
     ret (format_property_name __code_style $0.name) + '_Index'
 end
@@ -47,6 +51,36 @@ func generate_resolve_field_ref
             line1 = (get_ref_name field) + ' = new ' + (declaring_collection_ref_name field.ctype) + '();' + '\n'
 			line2 = 'foreach (var (_k,_v) in ' + fieldName + ') { ' + (get_ref_name field) + '.Add(_k, tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
 			ret line1 + line2
+		else
+			ret ''
+		end
+    else if can_generate_ref_group field
+        index = $1
+        refTables = get_ref_tables_from_ref_group field
+        refTable = refTables[index]
+        tableName = format_property_name __code_style refTable.name
+        if field.is_nullable
+            ret (get_ref_name_with_table_name field refTable.name) + ' = ' + fieldName + '!= null ? tables.' + tableName + '.GetOrDefault(' + (get_value_of_nullable_type field.ctype fieldName) + ') : null;'
+        else
+            ret (get_ref_name_with_table_name field refTable.name) + ' = tables.' + tableName + '.GetOrDefault(' + fieldName + ');'
+        end
+    else if can_generate_collection_ref_group field
+        index = $1
+        ref_tables = get_collection_ref_tables_from_ref_group field
+        ref_table = ref_tables[index]
+        tableName = format_property_name __code_style ref_table.name
+        if field.ctype.type_name == 'list' || field.ctype.type_name == 'set'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_collection_ref_name_from_ref_group field.ctype index) + '();' + '\n'
+            line2 = 'foreach (var _v in ' + fieldName + ') { ' + (get_ref_name_with_table_name field ref_table.name) + '.Add(tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
+            ret line1 + line2
+        else if field.ctype.type_name == 'array'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_type_name ref_table.value_ttype) + '[' + fieldName + '.Length];' + '\n'
+            line2 = 'for (int _i = 0; _i < ' + fieldName + '.Length; _i++) { ' + (get_ref_name_with_table_name field ref_table.name) + '[_i] = tables.' + tableName + '.GetOrDefault(' + fieldName + '[_i]); }' + '\n'
+            ret line1 + line2
+        else if field.ctype.type_name == 'map'
+            line1 = (get_ref_name_with_table_name field ref_table.name) + ' = new ' + (declaring_collection_ref_name_from_ref_group field.ctype index) + '();' + '\n'
+            line2 = 'foreach (var (_k,_v) in ' + fieldName + ') { ' + (get_ref_name_with_table_name field ref_table.name) + '.Add(_k, tables.' + tableName + '.GetOrDefault(_v)); }' + '\n'
+            ret line1 + line2
 		else
 			ret ''
 		end
@@ -113,6 +147,14 @@ public {{class_modifier __bean}} partial class {{__name}} : {{if parent_def_type
     public {{declaring_type_name (get_ref_type field)}} {{get_ref_name field}};
     {{~else if can_generate_collection_ref field~}}
     public {{declaring_collection_ref_name field.ctype}} {{get_ref_name field}};
+    {{~else if can_generate_ref_group field~}}
+        {{~for ref_table in (get_ref_tables_from_ref_group field)~}}
+    public {{declaring_type_name ref_table.value_ttype}} {{get_ref_name_with_table_name field ref_table.name}};
+        {{~end~}}
+    {{~else if can_generate_collection_ref_group field~}}
+        {{~for ref_table in (get_collection_ref_tables_from_ref_group field)~}}
+    public {{declaring_collection_ref_name_from_ref_group field.ctype for.index}} {{get_ref_name_with_table_name field ref_table.name}};
+        {{~end~}}
     {{~end~}}
    {{~if has_index field
         indexMapType = get_index_map_type field
@@ -132,7 +174,13 @@ public {{class_modifier __bean}} partial class {{__name}} : {{if parent_def_type
         base.ResolveRef(tables);
         {{~end~}}
         {{~for field in export_fields~}}
+            {{~if has_ref_group field~}}
+                {{~for index in 0..((get_ref_group_tables_count field) - 1)~}}
+        {{generate_resolve_field_ref field index}}
+                {{~end~}}
+            {{~else~}}
         {{generate_resolve_field_ref field}}
+            {{~end~}}
         {{~end~}}
     }
 

--- a/src/Luban.CSharp/TypeVisitors/DeclaringCollectionRefNameFromRefGroupVisitor.cs
+++ b/src/Luban.CSharp/TypeVisitors/DeclaringCollectionRefNameFromRefGroupVisitor.cs
@@ -4,67 +4,70 @@ using Luban.Types;
 using Luban.TypeVisitors;
 
 namespace Luban.CSharp.TypeVisitors;
-public class DeclaringCollectionRefNameVisitor : ITypeFuncVisitor<string>
+
+public class DeclaringCollectionRefNameFromRefGroupVisitor : ITypeFuncVisitor<int, string>
 {
-    public static DeclaringCollectionRefNameVisitor Ins { get; } = new();
-    public string Accept(TBool type)
+    public static DeclaringCollectionRefNameFromRefGroupVisitor Ins { get; } = new();
+
+    public string Accept(TBool type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TByte type)
+    public string Accept(TByte type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TShort type)
+    public string Accept(TShort type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TInt type)
+    public string Accept(TInt type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TLong type)
+    public string Accept(TLong type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TFloat type)
+    public string Accept(TFloat type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TDouble type)
+    public string Accept(TDouble type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TEnum type)
+    public string Accept(TEnum type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TString type)
+    public string Accept(TString type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TDateTime type)
+    public string Accept(TDateTime type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TBean type)
+    public string Accept(TBean type, int index)
     {
         throw new NotImplementedException();
     }
 
-    public string Accept(TArray type)
+    public string Accept(TArray type, int index)
     {
-        var refTable = GetCollectionRefTable(type);
+        var refTable = GetRefTable(type.ElementType, index);
+
         if (refTable != null)
         {
             return refTable.ValueTType.Apply(DeclaringTypeNameVisitor.Ins) + "[]";
@@ -72,9 +75,10 @@ public class DeclaringCollectionRefNameVisitor : ITypeFuncVisitor<string>
         throw new Exception($"解析'{type.ElementType}[]' 的ref失败");
     }
 
-    public string Accept(TList type)
+    public string Accept(TList type, int index)
     {
-        var refTable = GetCollectionRefTable(type);
+        var refTable = GetRefTable(type.ElementType, index);
+
         if (refTable != null)
         {
             return $"{ConstStrings.ListTypeName}<{refTable.ValueTType.Apply(DeclaringTypeNameVisitor.Ins)}>";
@@ -82,9 +86,10 @@ public class DeclaringCollectionRefNameVisitor : ITypeFuncVisitor<string>
         throw new Exception($"解析'{ConstStrings.ListTypeName}<{type.ElementType}>' 的ref失败");
     }
 
-    public string Accept(TSet type)
+    public string Accept(TSet type, int index)
     {
-        var refTable = GetCollectionRefTable(type);
+        var refTable = GetRefTable(type.ElementType, index);
+
         if (refTable != null)
         {
             return $"{ConstStrings.HashSetTypeName}<{refTable.ValueTType.Apply(DeclaringTypeNameVisitor.Ins)}>";
@@ -92,16 +97,17 @@ public class DeclaringCollectionRefNameVisitor : ITypeFuncVisitor<string>
         throw new Exception($"解析'{ConstStrings.HashSetTypeName}<{type.ElementType}>' 的ref失败");
     }
 
-    public string Accept(TMap type)
+    public string Accept(TMap type, int index)
     {
-        var refTable = GetCollectionRefTable(type);
+        var refTable = GetRefTable(type, index);
         if (refTable != null)
         {
             return $"{ConstStrings.HashMapTypeName}<{type.KeyType.Apply(DeclaringTypeNameVisitor.Ins)}, {refTable.ValueTType.Apply(DeclaringTypeNameVisitor.Ins)}>";
         }
         throw new Exception($"解析'{ConstStrings.HashMapTypeName}<{type.KeyType}, {type.ValueType}>' 的ref失败");
     }
-    private static DefTable GetCollectionRefTable(TType type)
+
+    private static DefTable GetRefTable(TType type, int index)
     {
         var refTag = type.GetTag("ref");
         if (refTag == null)
@@ -112,10 +118,11 @@ public class DeclaringCollectionRefNameVisitor : ITypeFuncVisitor<string>
         {
             return null;
         }
-        if (GenerationContext.Current.Assembly.GetCfgTable(refTag.Replace("?", "")) is { } cfgTable)
+        var refTables = TypeTemplateExtension.DoGetRefTablesFromRefGroup(refTag);
+        if (index < 0 || index >= refTables.Count)
         {
-            return cfgTable;
+            throw new Exception($"index:{index} out of range");
         }
-        return null;
+        return refTables[index];
     }
 }

--- a/src/Luban.DataValidator.Builtin/Ref/RefValidator.cs
+++ b/src/Luban.DataValidator.Builtin/Ref/RefValidator.cs
@@ -67,13 +67,12 @@ public class RefValidator : DataValidatorBase
     {
         var genCtx = GenerationContext.Current;
         var excludeTags = genCtx.ExcludeTags;
-
         foreach (var tableInfo in _compiledTables)
         {
             var (defTable, field, zeroAble) = tableInfo;
             if (zeroAble && key.Apply(IsDefaultValueVisitor.Ins))
             {
-                return;
+                continue;
             }
 
             switch (defTable.Mode)
@@ -92,7 +91,7 @@ public class RefValidator : DataValidatorBase
                             s_logger.Error("记录 {} = {} (来自文件:{}) 在引用表:{} 中存在，但导出时被过滤了",
                                 RecordPath, key, Source, defTable.FullName);
                         }
-                        return;
+                        continue;
                     }
                     break;
                 }
@@ -106,20 +105,17 @@ public class RefValidator : DataValidatorBase
                             s_logger.Error("记录 {} = {} (来自文件:{}) 在引用表:{} 中存在，但导出时被过滤了",
                                 RecordPath, key, Source, defTable.FullName);
                         }
-                        return;
+                        continue;
                     }
                     break;
                 }
                 default:
                     throw new NotSupportedException();
             }
-        }
 
-        foreach (var table in _compiledTables)
-        {
-            s_logger.Error("记录 {} = {} (来自文件:{}) 在引用表:{} 中不存在", RecordPath, key, Source, table.Table.FullName);
+            s_logger.Error("记录 {} = {} (来自文件:{}) 在引用表:{} 中不存在", RecordPath, key, Source, defTable.FullName);
+            GenerationContext.Current.LogValidatorFail(this);
         }
-        GenerationContext.Current.LogValidatorFail(this);
     }
 
     private static (string TableName, string FieldName, bool IgnoreDefault) ParseRefString(string refStr)


### PR DESCRIPTION
举例：
`  <refgroup name="test_ref_group" ref="test.TbTestBeRef,test.TbTestBeRef2"/>`
这个refgroup只会检查test.TbTestBeRef而不会检查test.TbTestBeRef2