### PR TITLE
[fix] remove empty lines in typescript-json resolve function

### DIFF
--- a/src/Luban.Typescript/Templates/typescript-json/schema.sbn
+++ b/src/Luban.Typescript/Templates/typescript-json/schema.sbn
@@ -26,6 +26,14 @@ func get_ref_name
     ret (format_property_name __code_style $0.name) + '_ref'
 end
 
+func should_resolve_field
+    field = $0
+    if ((can_generate_ref field) || (is_field_bean_need_resolve_ref field) || (is_field_array_like_need_resolve_ref field) || (is_field_map_need_resolve_ref field)) 
+        ret true
+    end
+    ret false
+end
+
 func generate_resolve_field_ref
     field = $0
     fieldName = format_property_name __code_style field.name
@@ -101,7 +109,9 @@ export {{if bean.is_abstract_type}}abstract {{end}}class {{bean.name}}{{if bean.
         super.resolve(tables)
         {{~end~}}
         {{~ for field in bean.export_fields ~}}
+        {{~if should_resolve_field field ~}}
         {{generate_resolve_field_ref field}}
+        {{~end~}}
         {{~end~}}
     }
 }


### PR DESCRIPTION
当前 typescript-json 的代码中 bean 的 resolve 函数有很多空行，因为每个 field 都会来上一行，无论是否需要resolve。
这个 commit 在生成前判断一下是否为空，不为空再生成对应resolve。可能 scriban 有更优雅的解决方案，但大体搂了一眼没找到。
apply 后 luban_example 中对应的 schema.ts 文件由 5144 行减少到 4853 行。