### PR TITLE
fix FileUtil.IsIgnoreFile when path have /./

### DIFF
--- a/src/Luban.Core/Utils/FileUtil.cs
+++ b/src/Luban.Core/Utils/FileUtil.cs
@@ -228,6 +228,7 @@ public static class FileUtil
 
     public static bool IsIgnoreFile(string file)
     {
+        file = Path.GetFullPath(file);
         return file.Split('\\', '/').Any(fileName => fileName.StartsWith(".") || fileName.StartsWith("_") || fileName.StartsWith("~"));
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/47bc759a-914b-4276-b0a5-e9417b29f4b5)
修复类似这种配置路径会被错误忽略的问题