### PR TITLE
[fix] 增加自动导入时 RwaTable、RwaBean、RawField 的 Tags 默认值，保持和从 Excel、Xml 导入定义时行为一致

### DIFF
--- a/src/Luban.Schema.Builtin/BeanSchemaFromExcelHeaderLoader.cs
+++ b/src/Luban.Schema.Builtin/BeanSchemaFromExcelHeaderLoader.cs
@@ -25,6 +25,7 @@ public class BeanSchemaFromExcelHeaderLoader : IBeanSchemaLoader
             Parent = "",
             Groups = new(),
             Fields = new(),
+            Tags = new Dictionary<string, string>(),
         };
 
 
@@ -81,6 +82,7 @@ public class BeanSchemaFromExcelHeaderLoader : IBeanSchemaLoader
                 Name = name,
                 Groups = new List<string>(),
                 Variants = new List<string>(),
+                Tags = new Dictionary<string, string>(),
             };
 
             string[] attrs = f.Type.Trim().Split('&').Select(s => s.Trim()).ToArray();

--- a/src/Luban.Schema.Builtin/DefaultTableImporter.cs
+++ b/src/Luban.Schema.Builtin/DefaultTableImporter.cs
@@ -68,6 +68,7 @@ public class DefaultTableImporter : ITableImporter
                 Groups = new List<string> { },
                 InputFiles = new List<string> { relativePath },
                 OutputFile = "",
+                Tags = new Dictionary<string, string>(),
             };
             s_logger.Debug("import table file:{@}", table);
             tables.Add(table);


### PR DESCRIPTION
从 Excel 和 Xml 导入定义时 Tags 默认值是一个没有元素的 Dictionary 集合，而自动导入定义时 Tags 默认值 null。
如果代码模板中使用了 tags 可能会报空指针。例如：
```
{{if __table.tags["tag"] == "test"}}
// {{__table.tags["tag"]}}
{{end}}
```
![image](https://github.com/user-attachments/assets/87412f6c-82f1-480d-b230-8ed17ef909df)
