### PR TITLE
feat: 扩展TextKeyListDataTarget，允许用户配置指定的`tag`；扩展其能力，支持从嵌套的bean中解析通过字段指定的`tag`。

### DIFF
--- a/src/Luban.Core/BuiltinOptionNames.cs
+++ b/src/Luban.Core/BuiltinOptionNames.cs
@@ -75,4 +75,6 @@ public static class BuiltinOptionNames
     public const string LineEnding = "lineEnding";
 
     public const string FileEncoding = "fileEncoding";
+
+    public const string TextCollectTag = "textCollectTag";
 }

--- a/src/Luban.L10N/DataTarget/TextKeyListCollectorVisitor.cs
+++ b/src/Luban.L10N/DataTarget/TextKeyListCollectorVisitor.cs
@@ -24,6 +24,7 @@ using Luban.Datas;
 using Luban.DataVisitors;
 using Luban.Defs;
 using Luban.Types;
+using Luban.Utils;
 
 namespace Luban.L10N.DataTarget;
 
@@ -31,7 +32,7 @@ namespace Luban.L10N.DataTarget;
 /// <summary>
 /// 检查 相同key的text,原始值必须相同
 /// </summary>
-public class TextKeyListCollectorVisitor : IDataActionVisitor2<TextKeyCollection>
+public class TextKeyListCollectorVisitor(string tag = "text") : IDataActionVisitor2<TextKeyCollection>
 {
     public static TextKeyListCollectorVisitor Ins { get; } = new TextKeyListCollectorVisitor();
 
@@ -77,7 +78,7 @@ public class TextKeyListCollectorVisitor : IDataActionVisitor2<TextKeyCollection
 
     public void Accept(DString data, TType type, TextKeyCollection x)
     {
-        if (data != null && type.HasTag("text"))
+        if (data != null && type.HasTag(tag))
         {
             x.AddKey(data.Value);
         }
@@ -90,7 +91,13 @@ public class TextKeyListCollectorVisitor : IDataActionVisitor2<TextKeyCollection
 
     public void Accept(DBean data, TType type, TextKeyCollection x)
     {
-
+        foreach (var tf in data.ImplType.Fields)
+        {
+            if (data.GetField(tf.Name) is DString ts && tf.HasTag(tag))
+            {
+                x.AddKey(ts.Value);
+            }
+        }
     }
 
     public void Accept(DArray data, TType type, TextKeyCollection x)

--- a/src/Luban.L10N/DataTarget/TextKeyListDataTarget.cs
+++ b/src/Luban.L10N/DataTarget/TextKeyListDataTarget.cs
@@ -43,7 +43,7 @@ internal class TextKeyListDataTarget : DataTargetBase
     {
         var textCollection = new TextKeyCollection();
 
-        var visitor = new DataActionHelpVisitor2<TextKeyCollection>(TextKeyListCollectorVisitor.Ins);
+        var visitor = new DataActionHelpVisitor2<TextKeyCollection>(CreateVisitor());
 
         foreach (var table in tables)
         {
@@ -57,5 +57,15 @@ internal class TextKeyListDataTarget : DataTargetBase
         string outputFile = EnvManager.Current.GetOption(BuiltinOptionNames.L10NFamily, BuiltinOptionNames.L10NTextListFile, false);
 
         return CreateOutputFile(outputFile, content);
+    }
+    
+    private IDataActionVisitor2<TextKeyCollection> CreateVisitor()
+    {
+        if (EnvManager.Current.TryGetOption(Name, BuiltinOptionNames.TextCollectTag, false, out var optionTag))
+        {
+            return string.IsNullOrWhiteSpace(optionTag) ? TextKeyListCollectorVisitor.Ins : new TextKeyListCollectorVisitor(optionTag);
+        }
+
+        return TextKeyListCollectorVisitor.Ins;
     }
 }


### PR DESCRIPTION
原有的收集本地化字段内容的命令不变，扩展支持指定`tag`收集相关字段内容的功能。

```
dotnet Luban.dll -t all -d text-list ^
--conf D:\workspace2\luban_examples\DataTables\luban.conf ^
--validationFailAsError ^
-x outputDataDir=D:\workspace2\luban_examples\Projects\GenerateDatas\text ^
-x l10n.textListFile=texts.txt
-x text-list.textCollectTag=<user tag>
```

同时，支持bean的字段级别的`tag`，以及嵌套的bean、派生的bean等用法。