### PR TITLE
去掉导出lua数据时schema定义中class后的行尾空格，class定义后增加空行

### DIFF
--- a/src/Luban.Lua/Templates/lua-bin/schema.sbn
+++ b/src/Luban.Lua/Templates/lua-bin/schema.sbn
@@ -106,6 +106,7 @@ local function InitTypes(methods)
         {{~ for field in bean.export_fields~}}
          ---@field public {{field.name}} {{comment_type field.ctype}} {{-if field.comment != ''}} @{{escape_comment field.comment}}{{end}}
         {{~end~}}
+
             local class = {
                 {{~ for field in bean.export_fields~}}
                 { name='{{field.name}}', type='{{comment_type field.ctype}}'},
@@ -122,6 +123,7 @@ local function InitTypes(methods)
     {{~ for field in bean.export_fields~}}
          ---@field public {{field.name}} {{comment_type field.ctype}}
     {{~end~}}
+
         local class = SimpleClass()
         class._id = {{bean.id}}
         class._type_ = '{{bean.full_name}}'

--- a/src/Luban.Lua/Templates/lua-lua/schema.sbn
+++ b/src/Luban.Lua/Templates/lua-lua/schema.sbn
@@ -17,6 +17,7 @@ local beans = {}
     {{~ for field in bean.export_fields~}}
      ---@field public {{field.name}} {{comment_type field.ctype}} {{-if field.comment != ''}} @{{escape_comment field.comment}}{{end}}
     {{~end~}}
+
         local class = {
             {{~ for field in bean.export_fields~}}
             { name='{{field.name}}', type='{{comment_type field.ctype}}'},


### PR DESCRIPTION
1. 去掉导出lua数据时schema定义中class后的行尾空格
2. class定义后增加空行，避免ide插件错误识别字段
修改前：

<img width="290" height="127" alt="before" src="https://github.com/user-attachments/assets/a37c0ad0-8fdb-47c7-8955-6a01d4ab5fc4" />

<img width="437" height="170" alt="before-schema" src="https://github.com/user-attachments/assets/252bd0ca-c869-4b29-8360-c0c0195eddf4" />

修改后：

<img width="280" height="84" alt="after" src="https://github.com/user-attachments/assets/575accdc-3407-4417-b44b-548bc87352a2" />

<img width="437" height="191" alt="after-schema" src="https://github.com/user-attachments/assets/57e3273a-a504-43d2-bbdf-1cd3e63b64e0" />
