### PR TITLE
优化 Rust 表查询接口的 key 借用方式

### DIFF
--- a/src/Luban.Rust/Templates/rust-bin/mod.sbn
+++ b/src/Luban.Rust/Templates/rust-bin/mod.sbn
@@ -201,16 +201,24 @@ impl {{name}} {
         Ok(std::sync::Arc::new({{name}} { data_map, data_list }))
     }
 
-    pub fn get(&self, key: &{{key_type}}) -> Option<{{value_type}}> {
+    pub fn get<Q>(&self, key: &Q) -> Option<{{value_type}}>
+    where
+        {{key_type}}: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.data_map.get(key).map(|x| x.clone())
     }
 }
 
-impl std::ops::Index<{{key_type}}> for {{name}} {
+impl<Q> std::ops::Index<&Q> for {{name}}
+where
+    {{key_type}}: std::borrow::Borrow<Q>,
+    Q: std::hash::Hash + Eq + ?Sized,
+{
     type Output = {{value_type}};
 
-    fn index(&self, index: {{key_type}}) -> &Self::Output {
-        &self.data_map.get(&index).unwrap()
+    fn index(&self, index: &Q) -> &Self::Output {
+        self.data_map.get(index).unwrap()
     }
 }
 {{~else if table.is_list_table ~}}
@@ -252,14 +260,22 @@ impl {{name}} {
     }
 
     {{~if table.is_union_index~}}
-    pub fn get(&self, key: &({{array.each table.index_list @index_type_name | array.join ', '}})) -> Option<{{value_type}}> {
+    pub fn get<Q>(&self, key: &Q) -> Option<{{value_type}}>
+    where
+        ({{array.each table.index_list @index_type_name | array.join ', '}}): std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.data_map_union.get(key).map(|x| x.clone())
     }
     {{~else if !table.index_list.empty? ~}}
     {{~for idx in table.index_list
         index = format_property_name __code_style idx.index_field.name
     ~}}
-    pub fn get_by_{{index}}(&self, key: &{{declaring_type_name idx.type}}) -> Option<{{value_type}}> {
+    pub fn get_by_{{index}}<Q>(&self, key: &Q) -> Option<{{value_type}}>
+    where
+        {{declaring_type_name idx.type}}: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.data_map_{{index}}.get(key).map(|x| x.clone())
     }
     {{~end~}}

--- a/src/Luban.Rust/Templates/rust-json/mod.sbn
+++ b/src/Luban.Rust/Templates/rust-json/mod.sbn
@@ -203,16 +203,24 @@ impl {{name}} {
         Ok(std::sync::Arc::new({{name}} { data_map, data_list }))
     }
 
-    pub fn get(&self, key: &{{key_type}}) -> Option<{{value_type}}> {
+    pub fn get<Q>(&self, key: &Q) -> Option<{{value_type}}>
+    where
+        {{key_type}}: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.data_map.get(key).map(|x| x.clone())
     }
 }
 
-impl std::ops::Index<{{key_type}}> for {{name}} {
+impl<Q> std::ops::Index<&Q> for {{name}}
+where
+    {{key_type}}: std::borrow::Borrow<Q>,
+    Q: std::hash::Hash + Eq + ?Sized,
+{
     type Output = {{value_type}};
 
-    fn index(&self, index: {{key_type}}) -> &Self::Output {
-        &self.data_map.get(&index).unwrap()
+    fn index(&self, index: &Q) -> &Self::Output {
+        self.data_map.get(index).unwrap()
     }
 }
 {{~else if table.is_list_table ~}}
@@ -258,14 +266,22 @@ impl {{name}} {
     }
 
     {{~if table.is_union_index~}}
-    pub fn get(&self, key: &({{array.each table.index_list @index_type_name | array.join ', '}})) -> Option<{{value_type}}> {
+    pub fn get<Q>(&self, key: &Q) -> Option<{{value_type}}>
+    where
+        ({{array.each table.index_list @index_type_name | array.join ', '}}): std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.data_map_union.get(key).map(|x| x.clone())
     }
     {{~else if !table.index_list.empty? ~}}
     {{~for idx in table.index_list
         index = format_property_name __code_style idx.index_field.name
     ~}}
-    pub fn get_by_{{index}}(&self, key: &{{declaring_type_name idx.type}}) -> Option<{{value_type}}> {
+    pub fn get_by_{{index}}<Q>(&self, key: &Q) -> Option<{{value_type}}>
+    where
+        {{declaring_type_name idx.type}}: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.data_map_{{index}}.get(key).map(|x| x.clone())
     }
     {{~end~}}


### PR DESCRIPTION
## 概述

优化 Rust 代码生成中的表查询接口，使其更接近 `HashMap::get` 的使用方式。

之前 `String` key 的表会生成：

```rust
pub fn get(&self, key: &String) -> Option<V>
```

这会要求调用方必须传入 `&String`。如果调用方手上只有字符串字面量或 `&str`，就需要临时构造 `String`：

```rust
TABLES.TbBlackboard.get(&"demo".to_string());
```

这既使用不方便，也会造成一次不必要的内存分配。

现在改为泛型借用参数后，可以直接传 `&str`：

```rust
TABLES.TbBlackboard.get("demo");
TABLES.TbBlackboard["demo"];
```

## 验证

- `dotnet build src/Luban.sln --no-restore`
- 重新生成 Rust JSON / BIN 示例
- `Projects/Rust_Json` 执行 `cargo test` 通过
- `Projects/Rust_bin` 执行 `cargo test` 通过