### PR TITLE
The fields that can be exported should be set as indexes.

### DIFF
--- a/src/Luban.Core/Defs/DefTable.cs
+++ b/src/Luban.Core/Defs/DefTable.cs
@@ -112,8 +112,16 @@ public class DefTable : DefTypeBase
                 {
                     if (ValueTType.DefBean.TryGetField(Index, out var f, out var i))
                     {
-                        IndexField = f;
-                        IndexFieldIdIndex = i;
+                        if (f.NeedExport())
+                        {
+                            IndexField = f;
+                            IndexFieldIdIndex = i;
+                        }
+                        else
+                        {
+                            throw new Exception($"table:'{FullName}' 索引{f.Name}不能导出，请指定有效索引");
+                        }
+
                     }
                     else
                     {
@@ -126,22 +134,15 @@ public class DefTable : DefTypeBase
                 }
                 else
                 {
-                    var fields = ValueTType.DefBean.HierarchyFields;
-                    for (var i = 0; i < fields.Count; i++)
+                    var f = ValueTType.DefBean.HierarchyFields[0];
+
+                    if (!f.NeedExport())
                     {
-                        var field = fields[i];
-                        if (field.NeedExport())
-                        {
-                            IndexField = field;
-                            Index = IndexField.Name;
-                            IndexFieldIdIndex = i;
-                            break;
-                        }
+                        throw new Exception($"table:'{FullName}' 默认索引{f.Name}不能导出，请指定有效索引");
                     }
-                    if (string.IsNullOrWhiteSpace(Index))
-                    {
-                        throw new Exception($"table:'{FullName}' 必须定义至少一个可导出字段");
-                    }
+                    IndexField = f;
+                    Index = IndexField.Name;
+                    IndexFieldIdIndex = 0;
                 }
                 KeyTType = IndexField.CType;
                 Type = TMap.Create(false, null, KeyTType, ValueTType, false);

--- a/src/Luban.Core/Defs/DefTable.cs
+++ b/src/Luban.Core/Defs/DefTable.cs
@@ -125,9 +125,22 @@ public class DefTable : DefTypeBase
                 }
                 else
                 {
-                    IndexField = ValueTType.DefBean.HierarchyFields[0];
-                    Index = IndexField.Name;
-                    IndexFieldIdIndex = 0;
+                    var fields = ValueTType.DefBean.HierarchyFields;
+                    for (var i = 0; i < fields.Count; i++)
+                    {
+                        var field = fields[i];
+                        if (field.NeedExport())
+                        {
+                            IndexField = field;
+                            Index = IndexField.Name;
+                            IndexFieldIdIndex = i;
+                            break;
+                        }
+                    }
+                    if (string.IsNullOrWhiteSpace(Index))
+                    {
+                        throw new Exception($"table:'{FullName}' 必须定义至少一个可导出字段");
+                    }
                 }
                 KeyTType = IndexField.CType;
                 Type = TMap.Create(false, null, KeyTType, ValueTType, false);

--- a/src/Luban.Core/Defs/DefTable.cs
+++ b/src/Luban.Core/Defs/DefTable.cs
@@ -21,6 +21,7 @@
 using Luban.RawDefs;
 using Luban.Types;
 using Luban.TypeVisitors;
+using Luban.Utils;
 using Luban.Validator;
 
 namespace Luban.Defs;


### PR DESCRIPTION
<img width="1711" height="515" alt="image" src="https://github.com/user-attachments/assets/e823628a-4758-4374-873d-d35c31f40123" />
错误的将不导出的字段设为索引